### PR TITLE
try fix #30

### DIFF
--- a/src/screens/manga/MangaExtensions.tsx
+++ b/src/screens/manga/MangaExtensions.tsx
@@ -146,7 +146,7 @@ export default function MangaExtensions() {
             document.removeEventListener('dragover', dragOverHandler);
             input?.removeEventListener('change', changeHandler);
         };
-    }, []);
+    }, [extensions]); // useEffect only after <input> renders
 
     if (Object.entries(extensions).length === 0) {
         return <h3>loading...</h3>;


### PR DESCRIPTION
This ensures `<input>` gets rendered first before `input?.addEventListener` gets called