### PR TITLE
Set Fallback Image for broken Thumbnails

### DIFF
--- a/public/notFound.svg
+++ b/public/notFound.svg
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- Transparent placeholder as fallback for unsuccessful image loads -->
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="12" height="12">
 </svg>

--- a/src/components/SpinnerImage.tsx
+++ b/src/components/SpinnerImage.tsx
@@ -36,6 +36,7 @@ export default function SpinnerImage(props: IProps) {
         };
 
         img.onerror = () => {
+            // Setting to an actual image so CSS styling works consistently
             setImagsrc('/notFound.svg');
         };
 


### PR DESCRIPTION
Added a Fallback Image for the MangaCard onError, this allows the proper css scalings to work and thus fixing the scaling issue.
Fixes: #49 

Please ignore the Backbutton next to the Library Label. This is not included in this PR

# Before
<img width="1433" alt="Bildschirmfoto 2021-10-26 um 19 36 33" src="https://user-images.githubusercontent.com/5088968/138931533-08ef87f9-c4a0-4517-b0ab-46b4d3e26402.png">

# After
<img width="1378" alt="Bildschirmfoto 2021-10-26 um 19 33 22" src="https://user-images.githubusercontent.com/5088968/138931592-400a92b5-8162-4cc5-83be-ebc2658a071a.png">


