### PR TITLE
Add reader setting limiting page height to window size

### DIFF
--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -142,6 +142,7 @@ export const defaultReaderSettings = () => ({
     showPageNumber: true,
     continuesPageGap: false,
     loadNextonEnding: false,
+    fitToViewHeight: false,
     readerType: 'ContinuesVertical',
 } as IReaderSettings);
 
@@ -171,6 +172,12 @@ export default function ReaderNavBar(props: IProps) {
     const classes = useStyles(settings)();
 
     const setSettingValue = (key: string, value: any) => setSettings({ ...settings, [key]: value });
+    const showFitToHeight = new Set<ReaderType>([
+        'SingleRTL',
+        'SingleLTR',
+        'DoubleRTL',
+        'DoubleLTR',
+    ]).has(settings.readerType);
 
     const handleScroll = () => {
         const currentScrollPos = window.pageYOffset;
@@ -327,6 +334,17 @@ export default function ReaderNavBar(props: IProps) {
                                     </MenuItem>
                                 </Select>
                             </ListItem>
+                            {showFitToHeight
+                                ? (
+                                    <ListItem>
+                                        <ListItemText primary="Limit page height to window" />
+                                        <Switch
+                                            edge="end"
+                                            checked={settings.fitToViewHeight}
+                                            onChange={(e) => setSettingValue('fitToViewHeight', e.target.checked)}
+                                        />
+                                    </ListItem>
+                                ) : null}
                         </List>
                     </Collapse>
                     <hr />

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -50,6 +50,7 @@ function imageStyle(settings: IReaderSettings): any {
         minWidth: '50vw',
         width: dimensions.width < dimensions.height ? '100vw' : '100%',
         maxWidth: '100%',
+        maxHeight: settings.fitToViewHeight ? '99vh' : 'unset',
     };
 }
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -116,6 +116,7 @@ interface IReaderSettings{
     staticNav: boolean
     showPageNumber: boolean
     loadNextonEnding: boolean
+    fitToViewHeight: boolean
     readerType: ReaderType
 }
 


### PR DESCRIPTION
Implements #13 
Added Setting in Reader for horizontal paginated Readers. It limits the page size to the window height in these cases.
Setting only shows up for valid reader selections

![localhost_3000_manga_44_chapter_95(Small Laptop)](https://user-images.githubusercontent.com/5088968/139595841-811802c3-e79d-43b1-a577-fa8d19022b0f.png)
![localhost_3000_manga_44_chapter_95(iPhone X)](https://user-images.githubusercontent.com/5088968/139595840-c7c5e229-351e-46ba-bdfc-b0e1a9c947d1.png)
![localhost_3000_manga_44_chapter_95(Small Laptop) (1)](https://user-images.githubusercontent.com/5088968/139595837-bae99c4d-f017-416f-9b97-bda5dcf90c37.png)
![localhost_3000_manga_44_chapter_95(Small Laptop) (2)](https://user-images.githubusercontent.com/5088968/139595834-8f910db0-eb05-4714-85e9-ed4e8ebed257.png)

