### PR TITLE
Save tabs number in Url to persist tab when go to other paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,7 +158,7 @@ export default function App() {
                                     <Route path="/manga/:id">
                                         <Manga />
                                     </Route>
-                                    <Route path="/library">
+                                    <Route path="/library/:tabParamNumber?">
                                         <Library />
                                     </Route>
                                     <Route path="/updates">

--- a/src/components/navbar/DefaultNavBar.tsx
+++ b/src/components/navbar/DefaultNavBar.tsx
@@ -105,6 +105,7 @@ export default function DefaultNavBar() {
                 <Toolbar>
                     {
                         !navbarItems.some(({ path }) => path === history.location.pathname)
+                        && !history.location.pathname.startsWith('/library')
                             && (
                                 <IconButton
                                     edge="start"

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -16,6 +16,7 @@ import TabPanel from 'components/util/TabPanel';
 import LibraryOptions from 'components/library/LibraryOptions';
 import LibraryMangaGrid from 'components/library/LibraryMangaGrid';
 import LibrarySearch from 'components/library/LibrarySearch';
+import { useHistory, useParams } from 'react-router-dom';
 
 interface IMangaCategory {
     category: ICategory
@@ -34,14 +35,17 @@ export default function Library() {
         );
     }, []);
 
+    const { tabParamNumber } = useParams<{ tabParamNumber: string }>();
     const [tabs, setTabs] = useState<IMangaCategory[]>();
     const [tabNum, setTabNum] = useState<number>(0);
+    const history = useHistory();
 
     // a hack so MangaGrid doesn't stop working. I won't change it in case
     // if I do manga pagination for library..
     const [lastPageNum, setLastPageNum] = useState<number>(1);
 
     const handleTabChange = (newTab: number) => {
+        history.replace(`/library/${newTab}`);
         setTabNum(newTab);
     };
 
@@ -54,10 +58,11 @@ export default function Library() {
                     mangas: [] as IManga[],
                     isFetched: false,
                 }));
-
                 setTabs(categoryTabs);
                 if (categoryTabs.length > 0) {
-                    setTabNum(categoryTabs[0].category.order);
+                    setTabNum(tabParamNumber === undefined
+                        ? categoryTabs[0].category.order
+                        : Number(tabParamNumber));
                 }
             });
     }, []);

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -60,9 +60,15 @@ export default function Library() {
                 }));
                 setTabs(categoryTabs);
                 if (categoryTabs.length > 0) {
-                    setTabNum(tabParamNumber === undefined
-                        ? categoryTabs[0].category.order
-                        : Number(tabParamNumber));
+                    setTabNum(() => {
+                        if (tabParamNumber !== undefined
+                            && !Number.isNaN(tabParamNumber)
+                            && !!categories.find((cat) => cat.order === Number(tabParamNumber))) {
+                            return Number(tabParamNumber);
+                        }
+                        history.replace('/library');
+                        return categoryTabs[0].category.order;
+                    });
                 }
             });
     }, []);

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -45,7 +45,10 @@ export default function Library() {
     const [lastPageNum, setLastPageNum] = useState<number>(1);
 
     const handleTabChange = (newTab: number) => {
-        history.replace(`/library/${newTab}`);
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        history.location.search === ''
+            ? history.replace(`/library/${newTab}`)
+            : history.replace(`/library/${newTab}/${history.location.search}`);
         setTabNum(newTab);
     };
 


### PR DESCRIPTION
Adds an Optional parameter to the library path to provide which tab to go to. It also replaces the Tab Number in the url when tab is changed.