### PR TITLE
Improves the Images in MangaCard

### DIFF
--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -121,6 +121,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                             imgStyle={{
                                 height: '100%',
                                 width: '100%',
+                                objectFit: 'cover',
                             }}
                             spinnerStyle={{
                                 display: 'grid',


### PR DESCRIPTION
The Manga card Images don't Stretch or squish if the cover image of manga is of a different aspect ratio
previously 
![Screen Shot 2021-12-03 at 11 00 22](https://user-images.githubusercontent.com/84376771/144551611-581d924e-cd0f-423b-943d-33e32c405601.png)
This is how it looks now
![Screen Shot 2021-12-03 at 11 00 09](https://user-images.githubusercontent.com/84376771/144551666-245031e5-2a55-404d-a407-9e21a844ee3f.png)

