### PR TITLE
Rewrite Extension screen to enable search and to use a Virtual List

### DIFF
--- a/src/components/ExtensionSearch.tsx
+++ b/src/components/ExtensionSearch.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useState, useRef } from 'react';
+import SearchIcon from '@mui/icons-material/Search';
+import { IconButton, Input } from '@mui/material';
+import CancelIcon from '@mui/icons-material/Cancel';
+import { useQueryParam, StringParam } from 'use-query-params';
+
+export default function LibrarySearch() {
+    const [query, setQuery] = useQueryParam('query', StringParam);
+    const [searchOpen, setSearchOpen] = useState(!!query);
+    const inputRef = useRef<HTMLInputElement>();
+
+    function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+        setQuery(e.target.value === '' ? undefined : e.target.value);
+    }
+    const cancelSearch = () => {
+        setQuery(null);
+        setSearchOpen(false);
+    };
+    const handleBlur = () => {
+        if (!query) setSearchOpen(false);
+    };
+    const openSearch = () => {
+        setSearchOpen(true);
+        // Put Focus Action at the end of the Callstack so Input actually exists on the dom
+        setTimeout(() => {
+            if (inputRef && inputRef.current) inputRef.current.focus();
+        });
+    };
+    return (
+        <>
+            {searchOpen ? (
+                <Input
+                    value={query || ''}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    inputRef={inputRef}
+                    endAdornment={(
+                        <IconButton onClick={cancelSearch}>
+                            <CancelIcon />
+                        </IconButton>
+                    )}
+                />
+            ) : (
+                <SearchIcon onClick={openSearch} />
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
The Insertion of so many DOM element (around 950 Extension Cards at the time) was the Bottleneck during the Initial render and also when setting up search. So, the Extension screen now uses a Virtual List to Render the Extension List. Because of this query search can now also be used.