### PR TITLE
fix scrolling 8px

### DIFF
--- a/src/components/chapter/ChapterList.tsx
+++ b/src/components/chapter/ChapterList.tsx
@@ -27,8 +27,8 @@ const CustomVirtuoso = styled(Virtuoso)(({ theme }) => ({
     minHeight: '200px',
     [theme.breakpoints.up('md')]: {
         width: '50vw',
-        // 64px for the Appbar, 40px for the ChapterCount Header
-        height: 'calc(100vh - 64px - 40px)',
+        // 64px for the Appbar, 48px for the ChapterCount Header
+        height: 'calc(100vh - 64px - 48px)',
         margin: 0,
     },
 }));


### PR DESCRIPTION
spoke about in discord
ChapterCount Header has a top margin of 8px that wasn't accounted for, leading to scrolling 8px on every chapter page
haven't tested