### PR TITLE
more Download Queue info

### DIFF
--- a/src/screens/DownloadQueue.tsx
+++ b/src/screens/DownloadQueue.tsx
@@ -125,7 +125,9 @@ export default function DownloadQueue() {
                                             </ListItemIcon>
                                             <ListItemText
                                                 primary={
-                                                    `${item.chapter.name} | `
+                                                    `${item.manga.source.name} | `
+                                                + `${item.manga.title} | `
+                                                + `${item.chapter.name} | `
                                                 + ` (${(item.progress * 100).toFixed(2)}%)`
                                                 + ` => state: ${item.state}`
                                                 }

--- a/src/screens/DownloadQueue.tsx
+++ b/src/screens/DownloadQueue.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/jsx-props-no-spreading */

--- a/src/screens/DownloadQueue.tsx
+++ b/src/screens/DownloadQueue.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/jsx-props-no-spreading */
@@ -23,8 +24,11 @@ import List from '@mui/material/List';
 import DragHandleIcon from '@mui/icons-material/DragHandle';
 import ListItem from '@mui/material/ListItem';
 import { ListItemIcon } from '@mui/material';
-import ListItemText from '@mui/material/ListItemText';
 import EmptyView from 'components/util/EmptyView';
+
+import { Box } from '@mui/system';
+import Typography from '@mui/material/Typography';
+import { useHistory } from 'react-router-dom';
 
 const baseWebsocketUrl = JSON.parse(window.localStorage.getItem('serverBaseURL')!).replace('http', 'ws');
 
@@ -47,6 +51,8 @@ export default function DownloadQueue() {
     const [, setWsClient] = useState<WebSocket>();
     const [queueState, setQueueState] = useState<IQueue>(initialQueue);
     const { queue, status } = queueState;
+
+    const history = useHistory();
 
     const theme = useTheme();
 
@@ -111,6 +117,22 @@ export default function DownloadQueue() {
                                     {(provided, snapshot) => (
                                         <ListItem
                                             ContainerProps={{ ref: provided.innerRef } as any}
+                                            sx={{
+                                                display: 'flex',
+                                                justifyContent: 'flex-start',
+                                                alignItems: 'flex-start',
+                                                padding: 2,
+                                                margin: '10px',
+                                                '&:hover': {
+                                                    backgroundColor: 'action.hover',
+                                                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+                                                },
+                                                '&:active': {
+                                                    backgroundColor: 'action.selected',
+                                                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+                                                },
+                                            }}
+                                            onClick={() => history.push(`/manga/${item.chapter.mangaId}`)}
                                             {...provided.draggableProps}
                                             {...provided.dragHandleProps}
                                             style={getItemStyle(
@@ -120,21 +142,25 @@ export default function DownloadQueue() {
                                             )}
                                             ref={provided.innerRef}
                                         >
-                                            <ListItemIcon>
+                                            <ListItemIcon sx={{ margin: 'auto 0' }}>
                                                 <DragHandleIcon />
                                             </ListItemIcon>
-                                            <ListItemText
-                                                primary={
-                                                    `${item.manga.source.name} | `
-                                                + `${item.manga.title} | `
-                                                + `${item.chapter.name} | `
-                                                + ` (${(item.progress * 100).toFixed(2)}%)`
-                                                + ` => state: ${item.state}`
-                                                }
-                                            />
+                                            <Box sx={{ display: 'flex' }}>
+                                                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                                                    <Typography variant="h5" component="h2">
+                                                        {item.manga.title}
+                                                    </Typography>
+                                                    <Typography variant="caption" display="block" gutterBottom>
+                                                        {item.chapter.name}
+                                                    </Typography>
+                                                </Box>
+                                            </Box>
                                             <IconButton
-                                                onClick={() => {
-                                                // deleteCategory(index);
+                                                sx={{ marginLeft: 'auto' }}
+                                                onClick={(e) => {
+                                                    // deleteCategory(index);
+                                                    // prevent parent tags from getting the event
+                                                    e.stopPropagation();
                                                 }}
                                                 size="large"
                                             >
@@ -143,6 +169,7 @@ export default function DownloadQueue() {
                                         </ListItem>
                                     )}
                                 </Draggable>
+
                             ))}
                             {provided.placeholder}
                         </List>

--- a/src/screens/DownloadQueue.tsx
+++ b/src/screens/DownloadQueue.tsx
@@ -151,7 +151,9 @@ export default function DownloadQueue() {
                                                         {item.manga.title}
                                                     </Typography>
                                                     <Typography variant="caption" display="block" gutterBottom>
-                                                        {item.chapter.name}
+                                                        {`${item.chapter.name} `
+                                                        + `(${(item.progress * 100).toFixed(2)}%)`
+                                                        + ` => state: ${item.state}`}
                                                     </Typography>
                                                 </Box>
                                             </Box>

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -155,6 +155,7 @@ interface IDownloadChapter{
     state: 'Queued' | 'Downloading' | 'Finished' | 'Error'
     progress: number
     chapter: IChapter
+    manga: IManga
 }
 
 interface IQueue {


### PR DESCRIPTION
add Imanga type definition to IDownloadChapter

add source name to queue
add manga name to queue

i have some permanently errored downloads and had no information visible other than what chapter it was

before:
![Screenshot_20220224_190602](https://user-images.githubusercontent.com/30987265/155590428-52ff051b-b668-47ea-9cfa-c43cee890c80.png)
after:
![Screenshot_20220224_190624](https://user-images.githubusercontent.com/30987265/155590470-10b59fb8-dcf3-4bef-9b48-e7bbee27a6e9.png)

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->