### PR TITLE
Genre filter

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -48,7 +48,7 @@ function genreFilter(queryY: NullAndUndefined<any[]>, queryN: NullAndUndefined<a
             ret = !queryN.some((v: string) => genre.includes(v));
         }
         if (queryY) {
-            ret = ret && queryY.some((v: string) => genre.includes(v));
+            ret = ret && queryY.every((v: string) => genre.includes(v));
         }
         return ret;
     }

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -41,10 +41,16 @@ function queryFilter(query: NullAndUndefined<string>, { title }: IMangaCard): bo
 }
 
 // eslint-disable-next-line max-len
-function genreFilter(query: NullAndUndefined<{ [key: string]: NullAndUndefined<any>; }>, { genre }: IMangaCard): boolean {
-    if (query !== undefined && query !== null && Object.keys(query).length >= 1 && genre) {
-        const temp = genre.map((e) => query[e]);
-        return !temp.includes('false') && (Object.values(query).includes('true') ? temp.includes('true') : true);
+function genreFilter(queryY: NullAndUndefined<any[]>, queryN: NullAndUndefined<any[]>, { genre }: IMangaCard): boolean {
+    if (genre && (queryN || queryY)) {
+        let ret: boolean = true;
+        if (queryN) {
+            ret = !queryN.some((v: string) => genre.includes(v));
+        }
+        if (queryY) {
+            ret = ret && queryY.some((v: string) => genre.includes(v));
+        }
+        return ret;
     }
     return true;
 }
@@ -54,13 +60,14 @@ function filterManga(mangas: IMangaCard[]): IMangaCard[] {
         downloaded,
         unread,
         query,
-        queryGenre,
+        genreY,
+        genreN,
     } = useLibraryOptions();
     return mangas
         .filter((manga) => downloadedFilter(downloaded, manga)
         && unreadFilter(unread, manga)
         && queryFilter(query, manga)
-        && genreFilter(queryGenre, manga));
+        && genreFilter(genreY, genreN, manga));
 }
 
 function toReadSort(a: IMangaCard, b: IMangaCard): number {

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -101,10 +101,10 @@ export default function LibraryMangaGrid(props: IMangaGridProps) {
         mangas, isLoading, hasNextPage, lastPageNum, setLastPageNum, message,
     } = props;
 
-    const { active, query } = useLibraryOptions();
+    const { active, query, activeGenre } = useLibraryOptions();
     const filteredManga = filterManga(mangas);
     const sortedManga = sortManga(filteredManga);
-    const showFilteredOutMessage = (active || query)
+    const showFilteredOutMessage = (active || query || activeGenre)
         && filteredManga.length === 0 && mangas.length > 0;
 
     return (

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -40,12 +40,27 @@ function queryFilter(query: NullAndUndefined<string>, { title }: IMangaCard): bo
     return title.toLowerCase().includes(query.toLowerCase());
 }
 
+// eslint-disable-next-line max-len
+function genreFilter(query: NullAndUndefined<{ [key: string]: NullAndUndefined<any>; }>, { genre }: IMangaCard): boolean {
+    if (query !== undefined && query !== null && Object.keys(query).length >= 1 && genre) {
+        const temp = genre.map((e) => query[e]);
+        return !temp.includes('false') && (Object.values(query).includes('true') ? temp.includes('true') : true);
+    }
+    return true;
+}
+
 function filterManga(mangas: IMangaCard[]): IMangaCard[] {
-    const { downloaded, unread, query } = useLibraryOptions();
+    const {
+        downloaded,
+        unread,
+        query,
+        queryGenre,
+    } = useLibraryOptions();
     return mangas
         .filter((manga) => downloadedFilter(downloaded, manga)
         && unreadFilter(unread, manga)
-        && queryFilter(query, manga));
+        && queryFilter(query, manga)
+        && genreFilter(queryGenre, manga));
 }
 
 function toReadSort(a: IMangaCard, b: IMangaCard): number {

--- a/src/components/library/LibraryOptions.tsx
+++ b/src/components/library/LibraryOptions.tsx
@@ -16,6 +16,10 @@ import Switch from '@mui/material/Switch';
 import Radio from '@mui/material/Radio';
 import { Box } from '@mui/system';
 
+interface IGenres {
+    genres: string[]
+}
+
 function Options() {
     const {
         downloaded, setDownloaded, unread, setUnread,
@@ -51,10 +55,66 @@ function SortOptions() {
     );
 }
 
-export default function LibraryOptions() {
+function GenreOptions({ genres }: IGenres) {
+    const {
+        queryGenre,
+        setQueryGenre,
+    } = useLibraryOptions();
+
+    function handleGenreChange(ele: string, checked: any) {
+        const tmp = queryGenre || {};
+        if (checked !== undefined) {
+            tmp[ele] = checked;
+        } else {
+            delete tmp[ele];
+        }
+        setQueryGenre(tmp);
+    }
+
+    const ret = genres.map((ele) => {
+        let check: null | boolean;
+        if (queryGenre !== undefined
+            && queryGenre !== null
+            && Object.keys(queryGenre).length >= 1
+        ) {
+            switch (queryGenre[ele]) {
+                case 'true' || true:
+                    check = true;
+                    break;
+                case 'false' || false:
+                    check = false;
+                    break;
+                default:
+                    check = null;
+            }
+        } else { check = null; }
+
+        return (
+            <FormControlLabel
+                key={ele}
+                control={(
+                    <ThreeStateCheckbox
+                        name={ele}
+                        checked={check}
+                        onChange={(checked) => handleGenreChange(ele, checked)}
+                    />
+                )}
+                label={ele}
+            />
+        );
+    });
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {ret}
+        </Box>
+    );
+}
+
+export default function LibraryOptions({ genres }: IGenres) {
     const [filtersOpen, setFiltersOpen] = React.useState(false);
+    const [genreFiltersOpen, setGenreFiltersOpen] = React.useState(false);
     const [sortsOpen, setSortsOpen] = React.useState(false);
-    const { active } = useLibraryOptions();
+    const { active, activeSort } = useLibraryOptions();
     return (
         <>
             <IconButton
@@ -75,11 +135,27 @@ export default function LibraryOptions() {
                 }}
             >
                 <Options />
+                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    <IconButton
+                        sx={{
+                            marginRight: 'auto',
+                        }}
+                        onClick={() => {
+                            setFiltersOpen(false);
+                            setGenreFiltersOpen(!genreFiltersOpen);
+                        }}
+                        color={active ? 'warning' : 'default'}
+                        size="small"
+                    >
+                        <FilterListIcon />
+                        Genre Filter
+                    </IconButton>
+                </Box>
             </Drawer>
 
             <IconButton
                 onClick={() => setSortsOpen(!filtersOpen)}
-                color={active ? 'warning' : 'default'}
+                color={activeSort ? 'warning' : 'default'}
             >
                 <SortIcon />
             </IconButton>
@@ -95,6 +171,21 @@ export default function LibraryOptions() {
                 }}
             >
                 <SortOptions />
+            </Drawer>
+
+            <Drawer
+                anchor="right"
+                open={genreFiltersOpen}
+                onClose={() => setGenreFiltersOpen(false)}
+                PaperProps={{
+                    style: {
+                        maxWidth: 600, padding: '1em', marginLeft: 'auto', marginRight: 'auto',
+                    },
+                }}
+            >
+                <GenreOptions
+                    genres={genres}
+                />
             </Drawer>
 
         </>

--- a/src/components/library/LibraryOptions.tsx
+++ b/src/components/library/LibraryOptions.tsx
@@ -57,37 +57,35 @@ function SortOptions() {
 
 function GenreOptions({ genres }: IGenres) {
     const {
-        queryGenre,
-        setQueryGenre,
+        genreY,
+        setGenreY,
+        genreN,
+        setGenreN,
     } = useLibraryOptions();
 
-    function handleGenreChange(ele: string, checked: any) {
-        const tmp = queryGenre || {};
-        if (checked !== undefined) {
-            tmp[ele] = checked;
-        } else {
-            delete tmp[ele];
+    function handleGenreChange(ele: string, checked: boolean | undefined | null) {
+        switch (checked) {
+            case true:
+                setGenreY([...Array.from(genreY || []), ele]);
+                break;
+            case false:
+                setGenreY(genreY?.filter((e) => e !== ele));
+                setGenreN([...Array.from(genreN || []), ele]);
+                break;
+            default:
+                setGenreN(genreN?.filter((e) => e !== ele));
         }
-        setQueryGenre(tmp);
     }
 
     const ret = genres.map((ele) => {
         let check: null | boolean;
-        if (queryGenre !== undefined
-            && queryGenre !== null
-            && Object.keys(queryGenre).length >= 1
-        ) {
-            switch (queryGenre[ele]) {
-                case 'true' || true:
-                    check = true;
-                    break;
-                case 'false' || false:
-                    check = false;
-                    break;
-                default:
-                    check = null;
-            }
-        } else { check = null; }
+        if (genreY?.find((elem) => elem === ele)) {
+            check = true;
+        } else if (genreN?.find((elem) => elem === ele)) {
+            check = false;
+        } else {
+            check = null;
+        }
 
         return (
             <FormControlLabel

--- a/src/components/library/LibraryOptions.tsx
+++ b/src/components/library/LibraryOptions.tsx
@@ -112,7 +112,7 @@ export default function LibraryOptions({ genres }: IGenres) {
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [genreFiltersOpen, setGenreFiltersOpen] = React.useState(false);
     const [sortsOpen, setSortsOpen] = React.useState(false);
-    const { active, activeSort } = useLibraryOptions();
+    const { active, activeSort, activeGenre } = useLibraryOptions();
     return (
         <>
             <IconButton
@@ -142,7 +142,7 @@ export default function LibraryOptions({ genres }: IGenres) {
                             setFiltersOpen(false);
                             setGenreFiltersOpen(!genreFiltersOpen);
                         }}
-                        color={active ? 'warning' : 'default'}
+                        color={activeGenre ? 'warning' : 'default'}
                         size="small"
                     >
                         <FilterListIcon />

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -26,14 +26,6 @@ interface IMangaCategory {
 
 export default function Library() {
     const { setTitle, setAction } = useContext(NavbarContext);
-    useEffect(() => {
-        setTitle('Library'); setAction(
-            <>
-                <AppbarSearch />
-                <LibraryOptions />
-            </>,
-        );
-    }, []);
 
     const [tabs, setTabs] = useState<IMangaCategory[]>();
 
@@ -77,15 +69,23 @@ export default function Library() {
         if (tabs !== undefined) {
             tabs.forEach((tab, index) => {
                 if (tab.category.order === tabNum && !tab.isFetched) {
-                    // eslint-disable-next-line @typescript-eslint/no-shadow
                     client.get(`/api/v1/category/${tab.category.id}`)
                         .then((response) => response.data)
                         .then((data: IManga[]) => {
                             const tabsClone = cloneObject(tabs);
                             tabsClone[index].mangas = data;
                             tabsClone[index].isFetched = true;
-
                             setTabs(tabsClone);
+                            // eslint-disable-next-line max-len
+                            const genre = [...Array.from(new Set(data.flatMap((ele: IManga) => ele.genre)))].filter((e: string) => e !== '').sort();
+                            setTitle('Library'); setAction(
+                                <>
+                                    <AppbarSearch />
+                                    <LibraryOptions
+                                        genres={genre}
+                                    />
+                                </>,
+                            );
                         });
                 }
             });

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -36,6 +36,7 @@ interface IMangaCard {
     thumbnailUrl: string
     unreadCount?: number
     downloadCount?: number
+    genre?: string[]
 }
 
 interface IManga {

--- a/src/util/useLibraryOptions.ts
+++ b/src/util/useLibraryOptions.ts
@@ -19,6 +19,7 @@ interface IUseLibraryOptions {
     setQuery: (query: NullAndUndefined<string>) => void
     active: boolean
     activeSort: boolean
+    activeGenre: boolean
     sorts: NullAndUndefined<string>
     setSorts: (sorts: NullAndUndefined<string>) => void
     sortDesc: NullAndUndefined<boolean>
@@ -42,6 +43,8 @@ export default function useLibraryOptions(): IUseLibraryOptions {
     const active = unread != undefined || downloaded != undefined || genreY != undefined || genreN != undefined;
     // eslint-disable-next-line eqeqeq
     const activeSort = (sortDesc != undefined) || (sorts != undefined);
+    // eslint-disable-next-line eqeqeq
+    const activeGenre = genreY != undefined || genreN != undefined;
     return {
         downloaded,
         setDownloaded,
@@ -51,6 +54,7 @@ export default function useLibraryOptions(): IUseLibraryOptions {
         setQuery,
         active,
         activeSort,
+        activeGenre,
         sorts,
         setSorts,
         sortDesc,

--- a/src/util/useLibraryOptions.ts
+++ b/src/util/useLibraryOptions.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-    BooleanParam, useQueryParam, StringParam, ObjectParam,
+    BooleanParam, useQueryParam, StringParam, ArrayParam,
 } from 'use-query-params';
 
 interface IUseLibraryOptions {
@@ -23,8 +23,10 @@ interface IUseLibraryOptions {
     setSorts: (sorts: NullAndUndefined<string>) => void
     sortDesc: NullAndUndefined<boolean>
     setSortDesc: (sortDesc: NullAndUndefined<boolean>) => void
-    queryGenre: NullAndUndefined<{ [key: string]: NullAndUndefined<any>; }>
-    setQueryGenre: (queryGenre: NullAndUndefined<{ [key: string]: NullAndUndefined<any>; }>) => void
+    genreY: NullAndUndefined<any[]>
+    setGenreY: (genreY: NullAndUndefined<any[]>) => void
+    genreN: NullAndUndefined<any[]>
+    setGenreN: (genreN: NullAndUndefined<any[]>) => void
 }
 
 export default function useLibraryOptions(): IUseLibraryOptions {
@@ -33,12 +35,13 @@ export default function useLibraryOptions(): IUseLibraryOptions {
     const [query, setQuery] = useQueryParam('query', StringParam);
     const [sorts, setSorts] = useQueryParam('sorts', StringParam);
     const [sortDesc, setSortDesc] = useQueryParam('sortDesc', BooleanParam);
-    const [queryGenre, setQueryGenre] = useQueryParam('queryGenre', ObjectParam);
+    const [genreY, setGenreY] = useQueryParam('genreY', ArrayParam);
+    const [genreN, setGenreN] = useQueryParam('genreN', ArrayParam);
 
+    // eslint-disable-next-line eqeqeq, max-len
+    const active = unread != undefined || downloaded != undefined || genreY != undefined || genreN != undefined;
     // eslint-disable-next-line eqeqeq
-    const active = !(unread == undefined) || !(downloaded == undefined);
-    // eslint-disable-next-line eqeqeq
-    const activeSort = !(queryGenre == undefined || Object.keys(queryGenre).length >= 1);
+    const activeSort = (sortDesc != undefined) || (sorts != undefined);
     return {
         downloaded,
         setDownloaded,
@@ -52,7 +55,9 @@ export default function useLibraryOptions(): IUseLibraryOptions {
         setSorts,
         sortDesc,
         setSortDesc,
-        queryGenre,
-        setQueryGenre,
+        genreY,
+        setGenreY,
+        genreN,
+        setGenreN,
     };
 }

--- a/src/util/useLibraryOptions.ts
+++ b/src/util/useLibraryOptions.ts
@@ -6,7 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { BooleanParam, useQueryParam, StringParam } from 'use-query-params';
+import {
+    BooleanParam, useQueryParam, StringParam, ObjectParam,
+} from 'use-query-params';
 
 interface IUseLibraryOptions {
     downloaded: NullAndUndefined<boolean>
@@ -16,10 +18,13 @@ interface IUseLibraryOptions {
     query: NullAndUndefined<string>
     setQuery: (query: NullAndUndefined<string>) => void
     active: boolean
+    activeSort: boolean
     sorts: NullAndUndefined<string>
     setSorts: (sorts: NullAndUndefined<string>) => void
     sortDesc: NullAndUndefined<boolean>
     setSortDesc: (sortDesc: NullAndUndefined<boolean>) => void
+    queryGenre: NullAndUndefined<{ [key: string]: NullAndUndefined<any>; }>
+    setQueryGenre: (queryGenre: NullAndUndefined<{ [key: string]: NullAndUndefined<any>; }>) => void
 }
 
 export default function useLibraryOptions(): IUseLibraryOptions {
@@ -28,9 +33,12 @@ export default function useLibraryOptions(): IUseLibraryOptions {
     const [query, setQuery] = useQueryParam('query', StringParam);
     const [sorts, setSorts] = useQueryParam('sorts', StringParam);
     const [sortDesc, setSortDesc] = useQueryParam('sortDesc', BooleanParam);
+    const [queryGenre, setQueryGenre] = useQueryParam('queryGenre', ObjectParam);
 
     // eslint-disable-next-line eqeqeq
     const active = !(unread == undefined) || !(downloaded == undefined);
+    // eslint-disable-next-line eqeqeq
+    const activeSort = !(queryGenre == undefined || Object.keys(queryGenre).length >= 1);
     return {
         downloaded,
         setDownloaded,
@@ -39,9 +47,12 @@ export default function useLibraryOptions(): IUseLibraryOptions {
         query,
         setQuery,
         active,
+        activeSort,
         sorts,
         setSorts,
         sortDesc,
         setSortDesc,
+        queryGenre,
+        setQueryGenre,
     };
 }


### PR DESCRIPTION
added genre filter for manga in library
genre options are generated from all the manga currently in library (on manga load)
alphabetical order

also separated activeSort and active (filter) (yellow when active)

old:
![Screenshot_20220226_030814](https://user-images.githubusercontent.com/30987265/155826560-eab54697-8e89-4145-b047-ab2329923119.png)
new: (i couldn't get it to move in line with the check-boxes)
![Screenshot_20220226_030846](https://user-images.githubusercontent.com/30987265/155826571-d18ce625-619e-499c-afbe-b297368e642a.png)
clicking puts this on the right side of screen:
![Screenshot_20220226_031021](https://user-images.githubusercontent.com/30987265/155826609-53b7ee7f-0354-467b-a9a7-dc9f957b2ac1.png)

no issues as far as i can see, was mentioned in discord.
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->