### PR TITLE
source genre filter

### DIFF
--- a/src/components/source/SourceMangaGrid.tsx
+++ b/src/components/source/SourceMangaGrid.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React from 'react';
+import MangaGrid, { IMangaGridProps } from 'components/MangaGrid';
+import useLibraryOptions from 'util/useLibraryOptions';
+
+const FILTERED_OUT_MESSAGE = 'There are no Manga matching this filter';
+
+// eslint-disable-next-line max-len
+function genreFilter(queryY: NullAndUndefined<any[]>, queryN: NullAndUndefined<any[]>, { genre }: IMangaCard): boolean {
+    if (genre && (queryN || queryY)) {
+        let ret: boolean = true;
+        if (queryN) {
+            ret = !queryN.some((v: string) => genre.includes(v));
+        }
+        if (queryY) {
+            ret = ret && queryY.every((v: string) => genre.includes(v));
+        }
+        return ret;
+    }
+    return true;
+}
+
+function filterManga(mangas: IMangaCard[]): IMangaCard[] {
+    const {
+        genreY,
+        genreN,
+    } = useLibraryOptions();
+    if (genreN || genreY) {
+        return mangas
+            .filter((manga) => genreFilter(genreY, genreN, manga));
+    }
+    return mangas;
+}
+
+export default function SourceMangaGrid(props: IMangaGridProps) {
+    const {
+        mangas, isLoading, hasNextPage, lastPageNum, setLastPageNum, message, messageExtra,
+    } = props;
+
+    const { activeGenre } = useLibraryOptions();
+    const filteredManga = filterManga(mangas);
+    const showFilteredOutMessage = (activeGenre)
+        && filteredManga.length === 0 && mangas.length > 0;
+
+    return (
+        <MangaGrid
+            mangas={filteredManga}
+            isLoading={isLoading}
+            hasNextPage={hasNextPage}
+            lastPageNum={lastPageNum}
+            setLastPageNum={setLastPageNum}
+            message={showFilteredOutMessage ? FILTERED_OUT_MESSAGE : message}
+            messageExtra={messageExtra}
+        />
+    );
+}

--- a/src/components/source/SourceOptions.tsx
+++ b/src/components/source/SourceOptions.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React from 'react';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import { Drawer, FormControlLabel, IconButton } from '@mui/material';
+import useLibraryOptions from 'util/useLibraryOptions';
+import ThreeStateCheckbox from 'components/util/ThreeStateCheckbox';
+import { Box } from '@mui/system';
+
+interface IGenres {
+    genres: (string)[]
+}
+
+function GenreOptions({ genres }: IGenres) {
+    const {
+        genreY,
+        setGenreY,
+        genreN,
+        setGenreN,
+    } = useLibraryOptions();
+
+    function handleGenreChange(ele: string, checked: boolean | undefined | null) {
+        switch (checked) {
+            case true:
+                setGenreY([...Array.from(genreY || []), ele]);
+                break;
+            case false:
+                setGenreY(genreY?.filter((e) => e !== ele));
+                setGenreN([...Array.from(genreN || []), ele]);
+                break;
+            default:
+                setGenreN(genreN?.filter((e) => e !== ele));
+        }
+    }
+
+    const ret = genres.map((ele) => {
+        let check: null | boolean;
+        if (genreY?.find((elem) => elem === ele)) {
+            check = true;
+        } else if (genreN?.find((elem) => elem === ele)) {
+            check = false;
+        } else {
+            check = null;
+        }
+
+        return (
+            <FormControlLabel
+                key={ele}
+                control={(
+                    <ThreeStateCheckbox
+                        name={ele}
+                        checked={check}
+                        onChange={(checked) => handleGenreChange(ele, checked)}
+                    />
+                )}
+                label={ele}
+            />
+        );
+    });
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {ret}
+        </Box>
+    );
+}
+
+export default function SourceOptions({ genres }: IGenres) {
+    const [genreFiltersOpen, setGenreFiltersOpen] = React.useState(false);
+    const { activeGenre } = useLibraryOptions();
+    return (
+        <>
+            <IconButton
+                onClick={() => setGenreFiltersOpen(true)}
+                color={activeGenre ? 'warning' : 'default'}
+            >
+                <FilterListIcon />
+            </IconButton>
+
+            <Drawer
+                anchor="right"
+                open={genreFiltersOpen}
+                onClose={() => setGenreFiltersOpen(false)}
+                PaperProps={{
+                    style: {
+                        maxWidth: 600, padding: '1em', marginLeft: 'auto', marginRight: 'auto',
+                    },
+                }}
+            >
+                <GenreOptions
+                    genres={genres}
+                />
+            </Drawer>
+
+        </>
+    );
+}

--- a/src/screens/SourceMangas.tsx
+++ b/src/screens/SourceMangas.tsx
@@ -8,10 +8,11 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import IconButton from '@mui/material/IconButton';
-import MangaGrid from 'components/MangaGrid';
+import SourceMangaGrid from 'components/source/SourceMangaGrid';
 import NavbarContext from 'components/context/NavbarContext';
 import client from 'util/client';
 import SettingsIcon from '@mui/icons-material/Settings';
+import SourceOptions from 'components/source/SourceOptions';
 
 export default function SourceMangas(props: { popular: boolean }) {
     const { setTitle, setAction } = useContext(NavbarContext);
@@ -63,10 +64,22 @@ export default function SourceMangas(props: { popular: boolean }) {
                 setMangas([
                     ...mangas,
                     ...data.mangaList.map((it) => ({
-                        title: it.title, thumbnailUrl: it.thumbnailUrl, id: it.id,
+                        title: it.title, thumbnailUrl: it.thumbnailUrl, id: it.id, genre: it.genre,
                     }))]);
                 setHasNextPage(data.hasNextPage);
                 setFetched(true);
+                const genre = [...Array.from(new Set([
+                    ...mangas,
+                    ...data.mangaList.map((it) => ({
+                        genre: it.genre,
+                    }))].flatMap((ele) => ele.genre || '')))].sort();
+                setTitle('Library'); setAction(
+                    <>
+                        <SourceOptions
+                            genres={genre}
+                        />
+                    </>,
+                );
             });
     }, [lastPageNum]);
 
@@ -86,7 +99,7 @@ export default function SourceMangas(props: { popular: boolean }) {
     }
 
     return (
-        <MangaGrid
+        <SourceMangaGrid
             mangas={mangas}
             hasNextPage={hasNextPage}
             lastPageNum={lastPageNum}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -36,6 +36,7 @@ interface IMangaCard {
     thumbnailUrl: string
     unreadCount?: number
     downloadCount?: number
+    genre?: string[]
 }
 
 interface IManga {

--- a/src/util/useLibraryOptions.ts
+++ b/src/util/useLibraryOptions.ts
@@ -6,7 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { BooleanParam, useQueryParam, StringParam } from 'use-query-params';
+import {
+    BooleanParam, useQueryParam, StringParam, ArrayParam,
+} from 'use-query-params';
 
 interface IUseLibraryOptions {
     downloaded: NullAndUndefined<boolean>
@@ -16,10 +18,16 @@ interface IUseLibraryOptions {
     query: NullAndUndefined<string>
     setQuery: (query: NullAndUndefined<string>) => void
     active: boolean
+    activeSort: boolean
+    activeGenre: boolean
     sorts: NullAndUndefined<string>
     setSorts: (sorts: NullAndUndefined<string>) => void
     sortDesc: NullAndUndefined<boolean>
     setSortDesc: (sortDesc: NullAndUndefined<boolean>) => void
+    genreY: NullAndUndefined<any[]>
+    setGenreY: (genreY: NullAndUndefined<any[]>) => void
+    genreN: NullAndUndefined<any[]>
+    setGenreN: (genreN: NullAndUndefined<any[]>) => void
 }
 
 export default function useLibraryOptions(): IUseLibraryOptions {
@@ -28,9 +36,15 @@ export default function useLibraryOptions(): IUseLibraryOptions {
     const [query, setQuery] = useQueryParam('query', StringParam);
     const [sorts, setSorts] = useQueryParam('sorts', StringParam);
     const [sortDesc, setSortDesc] = useQueryParam('sortDesc', BooleanParam);
+    const [genreY, setGenreY] = useQueryParam('genreY', ArrayParam);
+    const [genreN, setGenreN] = useQueryParam('genreN', ArrayParam);
 
+    // eslint-disable-next-line eqeqeq, max-len
+    const active = unread != undefined || downloaded != undefined || genreY != undefined || genreN != undefined;
     // eslint-disable-next-line eqeqeq
-    const active = !(unread == undefined) || !(downloaded == undefined);
+    const activeSort = (sortDesc != undefined) || (sorts != undefined);
+    // eslint-disable-next-line eqeqeq
+    const activeGenre = genreY != undefined || genreN != undefined;
     return {
         downloaded,
         setDownloaded,
@@ -39,9 +53,15 @@ export default function useLibraryOptions(): IUseLibraryOptions {
         query,
         setQuery,
         active,
+        activeSort,
+        activeGenre,
         sorts,
         setSorts,
         sortDesc,
         setSortDesc,
+        genreY,
+        setGenreY,
+        genreN,
+        setGenreN,
     };
 }


### PR DESCRIPTION
only on /sources/*/popular/ right now
much the same as the library version #139

(source equivalent to library files have been created)
add filter button on top right goes to the genre list (since there are no other filters already)
genre list  generated from the current manga list
screenshots same as #139

can be glitchy when scrolling with a filter, idk how to fix 
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->