### PR TITLE
Close button fix

### DIFF
--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -203,7 +203,7 @@ export default function ReaderNavBar(props: IProps) {
                             color="inherit"
                             aria-label="menu"
                             disableRipple
-                            onClick={() => history.push('/library')}
+                            onClick={() => history.push('..')}
                             size="large"
                             sx={{ mr: -1 }}
                         >

--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -203,7 +203,7 @@ export default function ReaderNavBar(props: IProps) {
                             color="inherit"
                             aria-label="menu"
                             disableRipple
-                            onClick={() => history.goBack()}
+                            onClick={() => history.push('/library')}
                             size="large"
                             sx={{ mr: -1 }}
                         >


### PR DESCRIPTION
The close button in the reader menu now points up two levels (the relevant manga page) so in the case that it is clicked after loading up a manga directly via URL we aren't directed "back" to our previous location, and instead go to where it would normally be expected.  