### PR TITLE
add comfortable grid option

### DIFF
--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -13,7 +13,7 @@ import { Link } from 'react-router-dom';
 import { Grid } from '@mui/material';
 import useLocalStorage from 'util/useLocalStorage';
 import SpinnerImage from 'components/util/SpinnerImage';
-import { styled } from '@mui/system';
+import { Box, styled } from '@mui/system';
 import { useLibraryOptionsContext } from 'components/context/LibraryOptionsContext';
 
 const BottomGradient = styled('div')({
@@ -70,12 +70,14 @@ const truncateText = (str: string, maxLength: number) => {
 
 interface IProps {
     manga: IMangaCard
+    gridLayout: number | undefined
 }
 const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) => {
     const {
         manga: {
             id, title, thumbnailUrl, downloadCount, unreadCount: unread,
         },
+        gridLayout,
     } = props;
     const { options: { showUnreadBadge, showDownloadBadge } } = useLibraryOptionsContext();
 
@@ -84,60 +86,83 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
 
     return (
         <Grid item xs={6} sm={4} md={3} lg={2}>
-            <Link to={`/manga/${id}/`}>
-                <Card
+            <Link to={`/manga/${id}/`} style={(gridLayout === 1) ? { textDecoration: 'none' } : {}}>
+                <Box
                     sx={{
-                        // force standard aspect ratio of manga covers
-                        aspectRatio: '225/350',
                         display: 'flex',
+                        flexDirection: 'column',
                     }}
-                    ref={ref}
                 >
-                    <CardActionArea
+                    <Card
                         sx={{
-                            position: 'relative',
-                            height: '100%',
+                        // force standard aspect ratio of manga covers
+                            aspectRatio: '225/350',
+                            display: 'flex',
                         }}
+                        ref={ref}
                     >
-
-                        <BadgeContainer>
-                            { showUnreadBadge && unread! > 0 && (
-                                <Typography
-                                    sx={{ backgroundColor: 'primary.dark' }}
-                                >
-                                    {unread}
-                                </Typography>
-                            )}
-                            { showDownloadBadge && downloadCount! > 0 && (
-                                <Typography sx={{
-                                    backgroundColor: 'success.dark',
-                                }}
-                                >
-                                    {downloadCount}
-                                </Typography>
-                            )}
-                        </BadgeContainer>
-                        <SpinnerImage
-                            alt={title}
-                            src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
-                            imgStyle={{
+                        <CardActionArea
+                            sx={{
+                                position: 'relative',
                                 height: '100%',
-                                width: '100%',
-                                objectFit: 'cover',
                             }}
-                            spinnerStyle={{
-                                display: 'grid',
-                                placeItems: 'center',
-                            }}
-                        />
-                        <BottomGradient />
-                        <BottomGradientDoubledDown />
+                        >
 
-                        <MangaTitle>
+                            <BadgeContainer>
+                                { showUnreadBadge && unread! > 0 && (
+                                    <Typography
+                                        sx={{ backgroundColor: 'primary.dark' }}
+                                    >
+                                        {unread}
+                                    </Typography>
+                                )}
+                                { showDownloadBadge && downloadCount! > 0 && (
+                                    <Typography sx={{
+                                        backgroundColor: 'success.dark',
+                                    }}
+                                    >
+                                        {downloadCount}
+                                    </Typography>
+                                )}
+                            </BadgeContainer>
+                            <SpinnerImage
+                                alt={title}
+                                src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
+                                imgStyle={{
+                                    height: '100%',
+                                    width: '100%',
+                                    objectFit: 'cover',
+                                }}
+                                spinnerStyle={{
+                                    display: 'grid',
+                                    placeItems: 'center',
+                                }}
+                            />
+                            {(gridLayout === 1) ? (<></>) : (
+                                <>
+                                    <BottomGradient />
+                                    <BottomGradientDoubledDown />
+                                </>
+                            )}
+                            {(gridLayout === 1) ? (
+                                <></>
+                            ) : (
+                                <MangaTitle>
+                                    {truncateText(title, 61)}
+                                </MangaTitle>
+                            )}
+                        </CardActionArea>
+                    </Card>
+                    {(gridLayout === 1) ? (
+                        <MangaTitle
+                            sx={{
+                                position: 'relative',
+                            }}
+                        >
                             {truncateText(title, 61)}
                         </MangaTitle>
-                    </CardActionArea>
-                </Card>
+                    ) : (<></>)}
+                </Box>
             </Link>
         </Grid>
     );

--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -19,11 +19,13 @@ export interface IMangaGridProps{
     hasNextPage: boolean
     lastPageNum: number
     setLastPageNum: (lastPageNum: number) => void
+    gridLayout?: number | undefined
 }
 
 export default function MangaGrid(props: IMangaGridProps) {
     const {
-        mangas, isLoading, message, messageExtra, hasNextPage, lastPageNum, setLastPageNum,
+        mangas, isLoading, message, messageExtra,
+        hasNextPage, lastPageNum, setLastPageNum, gridLayout,
     } = props;
     let mapped;
     const lastManga = useRef<HTMLDivElement>(null);
@@ -61,6 +63,7 @@ export default function MangaGrid(props: IMangaGridProps) {
                         key={it.id}
                         manga={it}
                         ref={lastManga}
+                        gridLayout={gridLayout}
                     />
                 );
             }
@@ -68,6 +71,7 @@ export default function MangaGrid(props: IMangaGridProps) {
                 <MangaCard
                     key={it.id}
                     manga={it}
+                    gridLayout={gridLayout}
                 />
             );
         });

--- a/src/components/context/LibraryOptionsContext.tsx
+++ b/src/components/context/LibraryOptionsContext.tsx
@@ -8,12 +8,13 @@
 import React, { useContext } from 'react';
 
 type ContextType = {
+    // display options
     options: LibraryDisplayOptions;
     setOptions: React.Dispatch<React.SetStateAction<LibraryDisplayOptions>>;
 };
 
 const LibraryOptionsContext = React.createContext<ContextType>({
-    options: { showDownloadBadge: false, showUnreadBadge: false },
+    options: { showDownloadBadge: false, showUnreadBadge: false, gridLayout: 0 },
     setOptions: () => {},
 });
 

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import MangaGrid, { IMangaGridProps } from 'components/MangaGrid';
 import useLibraryOptions from 'util/useLibraryOptions';
+import { useLibraryOptionsContext } from 'components/context/LibraryOptionsContext';
 
 const FILTERED_OUT_MESSAGE = 'There are no Manga matching this filter';
 
@@ -79,6 +80,7 @@ export default function LibraryMangaGrid(props: IMangaGridProps) {
         mangas, isLoading, hasNextPage, lastPageNum, setLastPageNum, message,
     } = props;
 
+    const { options } = useLibraryOptionsContext();
     const { active, query } = useLibraryOptions();
     const filteredManga = filterManga(mangas);
     const sortedManga = sortManga(filteredManga);
@@ -93,6 +95,7 @@ export default function LibraryMangaGrid(props: IMangaGridProps) {
             lastPageNum={lastPageNum}
             setLastPageNum={setLastPageNum}
             message={showFilteredOutMessage ? FILTERED_OUT_MESSAGE : message}
+            gridLayout={options.gridLayout}
         />
     );
 }

--- a/src/components/library/LibraryOptions.tsx
+++ b/src/components/library/LibraryOptions.tsx
@@ -8,7 +8,6 @@
 
 import React, { useState } from 'react';
 import FilterListIcon from '@mui/icons-material/FilterList';
-import SortIcon from '@mui/icons-material/Sort';
 import {
     Drawer,
     FormControlLabel,
@@ -30,86 +29,39 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import TabPanel from 'components/util/TabPanel';
 import { useLibraryOptionsContext } from 'components/context/LibraryOptionsContext';
 
-function Options() {
+function filtersTab(currentTab: number) {
     const {
         downloaded, setDownloaded, unread, setUnread,
     } = useLibraryOptions();
-    const [currentTab, setCurrentTab] = useState<number>(0);
-    const { options, setOptions } = useLibraryOptionsContext();
-
-    function setContextOptions(
-        e: React.ChangeEvent<HTMLInputElement>,
-        checked: boolean,
-    ) {
-        setOptions((prev) => ({ ...prev, [e.target.name]: checked }));
-    }
-
     return (
-        <Box>
-            <Tabs
-                key={currentTab}
-                value={currentTab}
-                variant="fullWidth"
-                onChange={(e, newTab) => setCurrentTab(newTab)}
-                indicatorColor="primary"
-                textColor="primary"
-            >
-                <Tab label="Filter" value={0} />
-                <Tab label="Display" value={1} />
-            </Tabs>
-            <TabPanel index={0} currentIndex={currentTab}>
-                <Stack direction="column">
-                    <FormControlLabel
-                        control={(
-                            <ThreeStateCheckbox
-                                name="Unread"
-                                checked={unread}
-                                onChange={setUnread}
-                            />
-                        )}
-                        label="Unread"
-                    />
-                    <FormControlLabel
-                        control={(
-                            <ThreeStateCheckbox
-                                name="Downloaded"
-                                checked={downloaded}
-                                onChange={setDownloaded}
-                            />
-                        )}
-                        label="Downloaded"
-                    />
-                </Stack>
-            </TabPanel>
-            <TabPanel index={1} currentIndex={currentTab}>
-                <Stack direction="column">
-                    <FormControlLabel
-                        label="Unread Badges"
-                        control={(
-                            <Checkbox
-                                name="showUnreadBadge"
-                                checked={options.showUnreadBadge}
-                                onChange={setContextOptions}
-                            />
-                        )}
-                    />
-                    <FormControlLabel
-                        label="Download Badges"
-                        control={(
-                            <Checkbox
-                                name="showDownloadBadge"
-                                checked={options.showDownloadBadge}
-                                onChange={setContextOptions}
-                            />
-                        )}
-                    />
-                </Stack>
-            </TabPanel>
-        </Box>
+        <TabPanel index={0} currentIndex={currentTab}>
+            <Stack direction="column">
+                <FormControlLabel
+                    control={(
+                        <ThreeStateCheckbox
+                            name="Unread"
+                            checked={unread}
+                            onChange={setUnread}
+                        />
+                    )}
+                    label="Unread"
+                />
+                <FormControlLabel
+                    control={(
+                        <ThreeStateCheckbox
+                            name="Downloaded"
+                            checked={downloaded}
+                            onChange={setDownloaded}
+                        />
+                    )}
+                    label="Downloaded"
+                />
+            </Stack>
+        </TabPanel>
     );
 }
 
-function SortOptions() {
+function sortsTab(currentTab: number) {
     const {
         sorts, setSorts, sortDesc, setSortDesc,
     } = useLibraryOptions();
@@ -124,31 +76,95 @@ function SortOptions() {
 
     return (
         <>
-            {
-                ['sortToRead', 'sortAlph', 'sortID'].map((e) => {
-                    let icon;
-                    if (sorts === e) {
-                        icon = !sortDesc ? (<ArrowUpwardIcon color="primary" />)
-                            : (<ArrowDownwardIcon color="primary" />);
+            <TabPanel index={1} currentIndex={currentTab}>
+                <Stack direction="column">
+                    {
+                        ['sortToRead', 'sortAlph', 'sortID'].map((e) => {
+                            let icon;
+                            if (sorts === e) {
+                                icon = !sortDesc ? (<ArrowUpwardIcon color="primary" />)
+                                    : (<ArrowDownwardIcon color="primary" />);
+                            }
+                            icon = icon === undefined && sortDesc === undefined && e === 'sortID' ? (<ArrowDownwardIcon color="primary" />) : icon;
+                            return (
+                                <ListItem disablePadding>
+                                    <ListItemButton onClick={(event) => handleChange(event, e)}>
+                                        <ListItemIcon>{icon}</ListItemIcon>
+                                        <ListItemText primary={e} />
+                                    </ListItemButton>
+                                </ListItem>
+                            );
+                        })
                     }
-                    icon = icon === undefined && sortDesc === undefined && e === 'sortID' ? (<ArrowDownwardIcon color="primary" />) : icon;
-                    return (
-                        <ListItem disablePadding>
-                            <ListItemButton onClick={(event) => handleChange(event, e)}>
-                                <ListItemIcon>{icon}</ListItemIcon>
-                                <ListItemText primary={e} />
-                            </ListItemButton>
-                        </ListItem>
-                    );
-                })
-            }
+                </Stack>
+            </TabPanel>
         </>
+    );
+}
+
+function dispalyTab(currentTab: number) {
+    const { options, setOptions } = useLibraryOptionsContext();
+
+    function setContextOptions(
+        e: React.ChangeEvent<HTMLInputElement>,
+        checked: boolean,
+    ) {
+        setOptions((prev) => ({ ...prev, [e.target.name]: checked }));
+    }
+    return (
+        <TabPanel index={2} currentIndex={currentTab}>
+            <Stack direction="column">
+                <FormControlLabel
+                    label="Unread Badges"
+                    control={(
+                        <Checkbox
+                            name="showUnreadBadge"
+                            checked={options.showUnreadBadge}
+                            onChange={setContextOptions}
+                        />
+                    )}
+                />
+                <FormControlLabel
+                    label="Download Badges"
+                    control={(
+                        <Checkbox
+                            name="showDownloadBadge"
+                            checked={options.showDownloadBadge}
+                            onChange={setContextOptions}
+                        />
+                    )}
+                />
+            </Stack>
+        </TabPanel>
+    );
+}
+
+function Options() {
+    const [currentTab, setCurrentTab] = useState<number>(0);
+
+    return (
+        <Box>
+            <Tabs
+                key={currentTab}
+                value={currentTab}
+                variant="fullWidth"
+                onChange={(e, newTab) => setCurrentTab(newTab)}
+                indicatorColor="primary"
+                textColor="primary"
+            >
+                <Tab label="Filter" value={0} />
+                <Tab label="Sort" value={1} />
+                <Tab label="Display" value={2} />
+            </Tabs>
+            {filtersTab(currentTab)}
+            {sortsTab(currentTab)}
+            {dispalyTab(currentTab)}
+        </Box>
     );
 }
 
 export default function LibraryOptions() {
     const [filtersOpen, setFiltersOpen] = React.useState(false);
-    const [sortsOpen, setSortsOpen] = React.useState(false);
     const { active } = useLibraryOptions();
     return (
         <>
@@ -171,27 +187,6 @@ export default function LibraryOptions() {
             >
                 <Options />
             </Drawer>
-
-            <IconButton
-                onClick={() => setSortsOpen(!filtersOpen)}
-                color={active ? 'warning' : 'default'}
-            >
-                <SortIcon />
-            </IconButton>
-
-            <Drawer
-                anchor="bottom"
-                open={sortsOpen}
-                onClose={() => setSortsOpen(false)}
-                PaperProps={{
-                    style: {
-                        maxWidth: 600, padding: '1em', marginLeft: 'auto', marginRight: 'auto',
-                    },
-                }}
-            >
-                <SortOptions />
-            </Drawer>
-
         </>
     );
 }

--- a/src/components/library/LibraryOptions.tsx
+++ b/src/components/library/LibraryOptions.tsx
@@ -112,36 +112,6 @@ function dispalyTab(currentTab: number) {
     ) {
         setOptions((prev) => ({ ...prev, [e.target.name]: checked }));
     }
-    return (
-        <TabPanel index={2} currentIndex={currentTab}>
-            <Stack direction="column">
-                <FormControlLabel
-                    label="Unread Badges"
-                    control={(
-                        <Checkbox
-                            name="showUnreadBadge"
-                            checked={options.showUnreadBadge}
-                            onChange={setContextOptions}
-                        />
-                    )}
-                />
-                <FormControlLabel
-                    label="Download Badges"
-                    control={(
-                        <Checkbox
-                            name="showDownloadBadge"
-                            checked={options.showDownloadBadge}
-                            onChange={setContextOptions}
-                        />
-                    )}
-                />
-            </Stack>
-        </TabPanel>
-    );
-}
-
-function Options() {
-    const [currentTab, setCurrentTab] = useState<number>(0);
 
     function setGridContextOptions(
         e: React.ChangeEvent<HTMLInputElement>,

--- a/src/components/library/LibraryOptions.tsx
+++ b/src/components/library/LibraryOptions.tsx
@@ -21,6 +21,7 @@ import {
     ListItemButton,
     ListItemIcon,
     ListItemText,
+    Radio,
 } from '@mui/material';
 import useLibraryOptions from 'util/useLibraryOptions';
 import ThreeStateCheckbox from 'components/util/ThreeStateCheckbox';
@@ -111,9 +112,41 @@ function dispalyTab(currentTab: number) {
     ) {
         setOptions((prev) => ({ ...prev, [e.target.name]: checked }));
     }
+
+    function setGridContextOptions(
+        e: React.ChangeEvent<HTMLInputElement>,
+        checked: boolean,
+    ) {
+        if (checked) {
+            setOptions((prev) => ({ ...prev, gridLayout: parseInt(e.target.name, 10) }));
+        }
+    }
+
     return (
         <TabPanel index={2} currentIndex={currentTab}>
             <Stack direction="column">
+                DISPLAY MODE
+                <FormControlLabel
+                    label="Compact grid"
+                    control={(
+                        <Radio
+                            name="0"
+                            checked={options.gridLayout === 0 || options.gridLayout === undefined}
+                            onChange={setGridContextOptions}
+                        />
+                    )}
+                />
+                <FormControlLabel
+                    label="Comfortable grid"
+                    control={(
+                        <Radio
+                            name="1"
+                            checked={options.gridLayout === 1}
+                            onChange={setGridContextOptions}
+                        />
+                    )}
+                />
+                BADGES
                 <FormControlLabel
                     label="Unread Badges"
                     control={(

--- a/src/components/library/LibraryOptionsProvider.tsx
+++ b/src/components/library/LibraryOptionsProvider.tsx
@@ -15,7 +15,7 @@ interface IProps {
 
 export default function LibraryOptionsContextProvider({ children }: IProps) {
     const [options, setOptions] = useLocalStorage<LibraryDisplayOptions>('libraryOptions',
-        { showDownloadBadge: false, showUnreadBadge: false });
+        { showDownloadBadge: false, showUnreadBadge: false, gridLayout: 0 });
 
     return (
         <LibraryOptionsContext.Provider value={{ options, setOptions }}>

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -264,4 +264,5 @@ type ChapterOptionsReducerAction =
 interface LibraryDisplayOptions {
     showDownloadBadge: boolean
     showUnreadBadge: boolean
+    gridLayout: number
 }


### PR DESCRIPTION
make comfortable grid
tachiyomi has it, someone wants it
currently only library (sources will probably be my next pr)

![Screenshot_20220305_233944](https://user-images.githubusercontent.com/30987265/156903265-ddc7e026-a892-4a6b-b5a6-8d1f8bb8bc82.png)
comfortable:
![Screenshot_20220305_234031](https://user-images.githubusercontent.com/30987265/156903278-3b3e77d4-6795-4cd0-884c-6456b4a999e6.png)
compact:
![Screenshot_20220305_234058](https://user-images.githubusercontent.com/30987265/156903289-3d79faf7-954f-4ba7-9c2c-5448cc755b4c.png)

long names next to shot one looks kinda wierd, but tachiyomi does the same thing
![Screenshot_20220305_234225](https://user-images.githubusercontent.com/30987265/156903344-b32b74a6-4b23-44e3-919b-5f1317f44ceb.png)

closes #12
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->