### PR TITLE
in library badge to manga in sources

### DIFF
--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -75,7 +75,8 @@ interface IProps {
 const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) => {
     const {
         manga: {
-            id, title, thumbnailUrl, downloadCount, unreadCount: unread,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            id, title, thumbnailUrl, downloadCount, unreadCount: unread, inLibrary,
         },
         gridLayout,
     } = props;
@@ -110,6 +111,13 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                             >
 
                                 <BadgeContainer>
+                                    {inLibrary && (
+                                        <Typography
+                                            sx={{ backgroundColor: 'primary.dark', zIndex: '1' }}
+                                        >
+                                            In library
+                                        </Typography>
+                                    )}
                                     { showUnreadBadge && unread! > 0 && (
                                         <Typography
                                             sx={{ backgroundColor: 'primary.dark' }}
@@ -129,11 +137,18 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                 <SpinnerImage
                                     alt={title}
                                     src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
-                                    imgStyle={{
-                                        height: '100%',
-                                        width: '100%',
-                                        objectFit: 'cover',
-                                    }}
+                                    imgStyle={inLibrary
+                                        ? {
+                                            height: '100%',
+                                            width: '100%',
+                                            objectFit: 'cover',
+                                            filter: 'brightness(0.4)',
+                                        }
+                                        : {
+                                            height: '100%',
+                                            width: '100%',
+                                            objectFit: 'cover',
+                                        }}
                                     spinnerStyle={{
                                         display: 'grid',
                                         placeItems: 'center',

--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -204,13 +204,22 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                 >
                     <Avatar
                         variant="rounded"
-                        sx={{
-                            width: 56,
-                            height: 56,
-                            flex: '0 0 auto',
-                            marginRight: 2,
-                            imageRendering: 'pixelated',
-                        }}
+                        sx={inLibrary
+                            ? {
+                                width: 56,
+                                height: 56,
+                                flex: '0 0 auto',
+                                marginRight: 2,
+                                imageRendering: 'pixelated',
+                                filter: 'brightness(0.4)',
+                            }
+                            : {
+                                width: 56,
+                                height: 56,
+                                flex: '0 0 auto',
+                                marginRight: 2,
+                                imageRendering: 'pixelated',
+                            }}
                         src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
                     />
                     <Box
@@ -226,6 +235,13 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                         </Typography>
                     </Box>
                     <BadgeContainer sx={{ position: 'relative' }}>
+                        {inLibrary && (
+                            <Typography
+                                sx={{ backgroundColor: 'primary.dark', zIndex: '1' }}
+                            >
+                                In library
+                            </Typography>
+                        )}
                         { showUnreadBadge && unread! > 0 && (
                             <Typography
                                 sx={{ backgroundColor: 'primary.dark' }}

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -84,12 +84,17 @@ export default function LibraryMangaGrid(props: IMangaGridProps) {
     const { active, query } = useLibraryOptions();
     const filteredManga = filterManga(mangas);
     const sortedManga = sortManga(filteredManga);
+    const DoneManga = sortedManga.map((ele) => {
+        // eslint-disable-next-line no-param-reassign
+        ele.inLibrary = undefined;
+        return ele;
+    });
     const showFilteredOutMessage = (active || query)
         && filteredManga.length === 0 && mangas.length > 0;
 
     return (
         <MangaGrid
-            mangas={sortedManga}
+            mangas={DoneManga}
             isLoading={isLoading}
             hasNextPage={hasNextPage}
             lastPageNum={lastPageNum}

--- a/src/screens/SourceMangas.tsx
+++ b/src/screens/SourceMangas.tsx
@@ -175,6 +175,7 @@ export default function SourceMangas(props: { popular: boolean }) {
                             title: it.title,
                             thumbnailUrl: it.thumbnailUrl,
                             id: it.id,
+                            inLibrary: it.inLibrary,
                         }))]);
                     setHasNextPage(data.hasNextPage);
                     setFetched(true);

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -59,6 +59,7 @@ interface IMangaCard {
     thumbnailUrl: string
     unreadCount?: number
     downloadCount?: number
+    inLibrary?: boolean
 }
 
 interface IManga {


### PR DESCRIPTION
display when manga are already in library in sources
is something that tachiyomi does, just copying
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->
compact and comfortable are basically the same
![image](https://user-images.githubusercontent.com/30987265/156943943-0d58610a-2974-4c9b-b67e-861ac6695286.png)
