### PR TITLE
items per row setting

### DIFF
--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -71,6 +71,7 @@ const truncateText = (str: string, maxLength: number) => {
 interface IProps {
     manga: IMangaCard
     gridLayout: number | undefined
+    dimensions: number
 }
 const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) => {
     const {
@@ -79,21 +80,19 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
             id, title, thumbnailUrl, downloadCount, unreadCount: unread, inLibrary,
         },
         gridLayout,
+        dimensions,
     } = props;
     const { options: { showUnreadBadge, showDownloadBadge } } = useLibraryOptionsContext();
 
     const [serverAddress] = useLocalStorage<String>('serverBaseURL', '');
     const [useCache] = useLocalStorage<boolean>('useCache', true);
-
-    const [lg] = useLocalStorage<number>('lg', 6);
-    const [md] = useLocalStorage<number>('md', 4);
-    const [sm] = useLocalStorage<number>('sm', 3);
-    const [xs] = useLocalStorage<number>('xs', 2);
+    const [ItemWidth] = useLocalStorage<number>('ItemWidth', 300);
 
     if (gridLayout !== 2) {
+        const colomns = Math.round(dimensions / ItemWidth);
         return (
             // @ts-ignore gridsize type isnt allowed to be a decimal but it works fine
-            <Grid item xs={12 / xs} sm={12 / sm} md={12 / md} lg={12 / lg}>
+            <Grid item lg={12 / colomns}>
                 <Link to={`/manga/${id}/`} style={(gridLayout === 1) ? { textDecoration: 'none' } : {}}>
                     <Box
                         sx={{

--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -85,9 +85,15 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
     const [serverAddress] = useLocalStorage<String>('serverBaseURL', '');
     const [useCache] = useLocalStorage<boolean>('useCache', true);
 
+    const [lg] = useLocalStorage<number>('lg', 6);
+    const [md] = useLocalStorage<number>('md', 4);
+    const [sm] = useLocalStorage<number>('sm', 3);
+    const [xs] = useLocalStorage<number>('xs', 2);
+
     if (gridLayout !== 2) {
         return (
-            <Grid item xs={6} sm={4} md={3} lg={2}>
+            // @ts-ignore gridsize type isnt allowed to be a decimal but it works fine
+            <Grid item xs={12 / xs} sm={12 / sm} md={12 / md} lg={12 / lg}>
                 <Link to={`/manga/${id}/`} style={(gridLayout === 1) ? { textDecoration: 'none' } : {}}>
                     <Box
                         sx={{

--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -5,7 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useRef } from 'react';
+import React, {
+    useEffect, useLayoutEffect, useRef, useState,
+} from 'react';
 import Grid from '@mui/material/Grid';
 import EmptyView from 'components/util/EmptyView';
 import LoadingPlaceholder from 'components/util/LoadingPlaceholder';
@@ -49,6 +51,23 @@ export default function MangaGrid(props: IMangaGridProps) {
         };
     }, [hasNextPage, mangas]);
 
+    const [dimensions, setDimensions] = useState(1);
+
+    const gridRef = useRef<HTMLDivElement>(null);
+
+    const TestDimensions = () => {
+        setDimensions(gridRef.current ? gridRef.current.offsetWidth : 0);
+    };
+
+    useLayoutEffect(TestDimensions, []);
+
+    let movementTimer: NodeJS.Timeout;
+
+    window.addEventListener('resize', () => {
+        clearInterval(movementTimer);
+        movementTimer = setTimeout(TestDimensions, 100);
+    });
+
     if (mangas.length === 0) {
         if (isLoading) {
             mapped = (
@@ -79,6 +98,7 @@ export default function MangaGrid(props: IMangaGridProps) {
                         manga={it}
                         ref={lastManga}
                         gridLayout={gridLayout}
+                        dimensions={dimensions}
                     />
                 );
             }
@@ -87,30 +107,33 @@ export default function MangaGrid(props: IMangaGridProps) {
                     key={it.id}
                     manga={it}
                     gridLayout={gridLayout}
+                    dimensions={dimensions}
                 />
             );
         });
     }
 
     return (
-        <Grid
-            container
-            spacing={1}
-            style={horisontal ? {
-                margin: 0,
-                width: '100%',
-                padding: '5px',
-                overflowX: 'scroll',
-                display: '-webkit-inline-box',
-                flexWrap: 'nowrap',
-            } : {
-                margin: 0,
-                width: '100%',
-                padding: '5px',
-            }}
-        >
-            {mapped}
-        </Grid>
+        <div ref={gridRef}>
+            <Grid
+                container
+                spacing={1}
+                style={horisontal ? {
+                    margin: 0,
+                    width: '100%',
+                    padding: '5px',
+                    overflowX: 'scroll',
+                    display: '-webkit-inline-box',
+                    flexWrap: 'nowrap',
+                } : {
+                    margin: 0,
+                    width: '100%',
+                    padding: '5px',
+                }}
+            >
+                {mapped}
+            </Grid>
+        </div>
     );
 }
 

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -27,7 +27,8 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import TextField from '@mui/material/TextField';
 import FavoriteIcon from '@mui/icons-material/Favorite';
-import { ListItemButton } from '@mui/material';
+import Slider from '@mui/material/Slider';
+import { DialogTitle, ListItemButton } from '@mui/material';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import NavbarContext from '../components/context/NavbarContext';
 import DarkTheme from '../components/context/DarkTheme';
@@ -45,15 +46,9 @@ export default function Settings() {
     const [dialogOpen, setDialogOpen] = useState(false);
     const [dialogValue, setDialogValue] = useState(serverAddress);
 
-    const [dialogOpenMPerRow, setDialogOpenMPerRow] = useState(false);
-    const [lg, setLg] = useLocalStorage<number>('lg', 6);
-    const [md, setMd] = useLocalStorage<number>('md', 4);
-    const [sm, setSm] = useLocalStorage<number>('sm', 3);
-    const [xs, setXs] = useLocalStorage<number>('xs', 2);
-    const [DialogLg, setDialogLg] = useState(lg);
-    const [DialogMd, setDialogMd] = useState(md);
-    const [DialogSm, setDialogSm] = useState(sm);
-    const [DialogXs, setDialogXs] = useState(xs);
+    const [dialogOpenItemWidth, setDialogOpenItemWidth] = useState(false);
+    const [ItemWidth, setItemWidth] = useLocalStorage<number>('ItemWidth', 6);
+    const [DialogItemWidth, setDialogItemWidth] = useState(ItemWidth);
 
     const handleDialogOpen = () => {
         setDialogValue(serverAddress);
@@ -69,32 +64,27 @@ export default function Settings() {
         setServerAddress(dialogValue);
     };
 
-    const handleDialogOpenMPerRow = () => {
-        setDialogLg(lg);
-        setDialogMd(md);
-        setDialogSm(sm);
-        setDialogXs(xs);
-        setDialogOpenMPerRow(true);
+    const handleDialogOpenItemWidth = () => {
+        setDialogItemWidth(ItemWidth);
+        setDialogOpenItemWidth(true);
     };
 
-    const handleDialogCancelMPerRow = () => {
-        setDialogOpenMPerRow(false);
+    const handleDialogCancelItemWidth = () => {
+        setDialogOpenItemWidth(false);
     };
 
-    const handleDialogSubmitMPerRow = () => {
-        setDialogOpenMPerRow(false);
-        setLg(DialogLg);
-        setMd(DialogMd);
-        setSm(DialogSm);
-        setXs(DialogXs);
+    const handleDialogSubmitItemWidth = () => {
+        setDialogOpenItemWidth(false);
+        setItemWidth(DialogItemWidth);
     };
 
-    const handleDialogResetMPerRow = () => {
-        setDialogOpenMPerRow(false);
-        setLg(6);
-        setMd(4);
-        setSm(3);
-        setXs(2);
+    const handleDialogResetItemWidth = () => {
+        setDialogOpenItemWidth(false);
+        setItemWidth(300);
+    };
+
+    const handleChange = (event: Event, newValue: number | number[]) => {
+        setDialogItemWidth(newValue as number);
     };
 
     return (
@@ -130,10 +120,10 @@ export default function Settings() {
                         <ViewModuleIcon />
                     </ListItemIcon>
                     <ListItemText
-                        primary="Items per row"
-                        secondary={`lg:${lg} md:${md} sm:${sm} sx:${xs}`}
+                        primary="Manga Item width"
+                        secondary={`px:${ItemWidth}`}
                         onClick={() => {
-                            handleDialogOpenMPerRow();
+                            handleDialogOpenItemWidth();
                         }}
                     />
                 </ListItemButton>
@@ -221,53 +211,44 @@ export default function Settings() {
                 </DialogActions>
             </Dialog>
 
-            <Dialog open={dialogOpenMPerRow} onClose={handleDialogCancelMPerRow}>
-                <DialogContent>
-                    <DialogContentText>
-                        Items Per Row
-                    </DialogContentText>
+            <Dialog open={dialogOpenItemWidth} onClose={handleDialogCancelItemWidth}>
+                <DialogTitle>
+                    Manga Item width
+                </DialogTitle>
+                <DialogContent
+                    sx={{
+                        width: '98%',
+                        margin: 'auto',
+                    }}
+                >
                     <TextField
-                        sx={{ margin: 1 }}
-                        id="lg"
-                        label="lg"
+                        sx={{
+                            width: '100%',
+                            margin: 'auto',
+                        }}
                         autoFocus
+                        value={DialogItemWidth}
                         type="number"
-                        value={DialogLg}
-                        onChange={(e) => setDialogLg(parseInt(e.target.value, 10))}
+                        onChange={(e) => setDialogItemWidth(parseInt(e.target.value, 10))}
                     />
-                    <TextField
-                        sx={{ margin: 1 }}
-                        id="md"
-                        label="md"
-                        type="number"
-                        value={DialogMd}
-                        onChange={(e) => setDialogMd(parseInt(e.target.value, 10))}
-                    />
-                    <TextField
-                        sx={{ margin: 1 }}
-                        id="sm"
-                        label="sm"
-                        type="number"
-                        value={DialogSm}
-                        onChange={(e) => setDialogSm(parseInt(e.target.value, 10))}
-                    />
-                    <TextField
-                        sx={{ margin: 1 }}
-                        id="xs"
-                        label="xs"
-                        type="number"
-                        value={DialogXs}
-                        onChange={(e) => setDialogXs(parseInt(e.target.value, 10))}
+                    <Slider
+                        aria-label="Manga Item width"
+                        defaultValue={300}
+                        value={DialogItemWidth}
+                        step={10}
+                        min={100}
+                        max={1000}
+                        onChange={handleChange}
                     />
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={handleDialogResetMPerRow} color="primary">
+                    <Button onClick={handleDialogResetItemWidth} color="primary">
                         Reset to Default
                     </Button>
-                    <Button onClick={handleDialogCancelMPerRow} color="primary">
+                    <Button onClick={handleDialogCancelItemWidth} color="primary">
                         Cancel
                     </Button>
-                    <Button onClick={handleDialogSubmitMPerRow} color="primary">
+                    <Button onClick={handleDialogSubmitItemWidth} color="primary">
                         OK
                     </Button>
                 </DialogActions>

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -27,6 +27,8 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import TextField from '@mui/material/TextField';
 import FavoriteIcon from '@mui/icons-material/Favorite';
+import { ListItemButton } from '@mui/material';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import NavbarContext from '../components/context/NavbarContext';
 import DarkTheme from '../components/context/DarkTheme';
 import useLocalStorage from '../util/useLocalStorage';
@@ -43,6 +45,16 @@ export default function Settings() {
     const [dialogOpen, setDialogOpen] = useState(false);
     const [dialogValue, setDialogValue] = useState(serverAddress);
 
+    const [dialogOpenMPerRow, setDialogOpenMPerRow] = useState(false);
+    const [lg, setLg] = useLocalStorage<number>('lg', 6);
+    const [md, setMd] = useLocalStorage<number>('md', 4);
+    const [sm, setSm] = useLocalStorage<number>('sm', 3);
+    const [xs, setXs] = useLocalStorage<number>('xs', 2);
+    const [DialogLg, setDialogLg] = useState(lg);
+    const [DialogMd, setDialogMd] = useState(md);
+    const [DialogSm, setDialogSm] = useState(sm);
+    const [DialogXs, setDialogXs] = useState(xs);
+
     const handleDialogOpen = () => {
         setDialogValue(serverAddress);
         setDialogOpen(true);
@@ -55,6 +67,34 @@ export default function Settings() {
     const handleDialogSubmit = () => {
         setDialogOpen(false);
         setServerAddress(dialogValue);
+    };
+
+    const handleDialogOpenMPerRow = () => {
+        setDialogLg(lg);
+        setDialogMd(md);
+        setDialogSm(sm);
+        setDialogXs(xs);
+        setDialogOpenMPerRow(true);
+    };
+
+    const handleDialogCancelMPerRow = () => {
+        setDialogOpenMPerRow(false);
+    };
+
+    const handleDialogSubmitMPerRow = () => {
+        setDialogOpenMPerRow(false);
+        setLg(DialogLg);
+        setMd(DialogMd);
+        setSm(DialogSm);
+        setXs(DialogXs);
+    };
+
+    const handleDialogResetMPerRow = () => {
+        setDialogOpenMPerRow(false);
+        setLg(6);
+        setMd(4);
+        setSm(3);
+        setXs(2);
     };
 
     return (
@@ -85,6 +125,18 @@ export default function Settings() {
                         />
                     </ListItemSecondaryAction>
                 </ListItem>
+                <ListItemButton>
+                    <ListItemIcon>
+                        <ViewModuleIcon />
+                    </ListItemIcon>
+                    <ListItemText
+                        primary="Items per row"
+                        secondary={`lg:${lg} md:${md} sm:${sm} sx:${xs}`}
+                        onClick={() => {
+                            handleDialogOpenMPerRow();
+                        }}
+                    />
+                </ListItemButton>
                 <ListItem>
                     <ListItemIcon>
                         <FavoriteIcon />
@@ -165,6 +217,58 @@ export default function Settings() {
                     </Button>
                     <Button onClick={handleDialogSubmit} color="primary">
                         Set
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog open={dialogOpenMPerRow} onClose={handleDialogCancelMPerRow}>
+                <DialogContent>
+                    <DialogContentText>
+                        Items Per Row
+                    </DialogContentText>
+                    <TextField
+                        sx={{ margin: 1 }}
+                        id="lg"
+                        label="lg"
+                        autoFocus
+                        type="number"
+                        value={DialogLg}
+                        onChange={(e) => setDialogLg(parseInt(e.target.value, 10))}
+                    />
+                    <TextField
+                        sx={{ margin: 1 }}
+                        id="md"
+                        label="md"
+                        type="number"
+                        value={DialogMd}
+                        onChange={(e) => setDialogMd(parseInt(e.target.value, 10))}
+                    />
+                    <TextField
+                        sx={{ margin: 1 }}
+                        id="sm"
+                        label="sm"
+                        type="number"
+                        value={DialogSm}
+                        onChange={(e) => setDialogSm(parseInt(e.target.value, 10))}
+                    />
+                    <TextField
+                        sx={{ margin: 1 }}
+                        id="xs"
+                        label="xs"
+                        type="number"
+                        value={DialogXs}
+                        onChange={(e) => setDialogXs(parseInt(e.target.value, 10))}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleDialogResetMPerRow} color="primary">
+                        Reset to Default
+                    </Button>
+                    <Button onClick={handleDialogCancelMPerRow} color="primary">
+                        Cancel
+                    </Button>
+                    <Button onClick={handleDialogSubmitMPerRow} color="primary">
+                        OK
                     </Button>
                 </DialogActions>
             </Dialog>


### PR DESCRIPTION
adds setting to change the manga per rows (for compact and comfortable grid)
4 different settings cause 4 different widths catered for
idk what to name them for users to understand (need help) so am currently just using the codenames
(tachiyomi just has landscape and portrait so not applicable)
![Screenshot_20220324_003948](https://user-images.githubusercontent.com/30987265/159819123-3307daec-87fc-45b1-9799-0476eefd3b8a.png)
![Screenshot_20220324_004000](https://user-images.githubusercontent.com/30987265/159819141-0a035e30-8117-4d7c-b097-01cd3ed1764a.png)
lg = 10 example:
![Screenshot_20220324_004041](https://user-images.githubusercontent.com/30987265/159819215-c5a2e184-008a-44de-a5c7-f22674d2b0a1.png)

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->