### PR TITLE
fix default manga item width

### DIFF
--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -47,7 +47,7 @@ export default function Settings() {
     const [dialogValue, setDialogValue] = useState(serverAddress);
 
     const [dialogOpenItemWidth, setDialogOpenItemWidth] = useState(false);
-    const [ItemWidth, setItemWidth] = useLocalStorage<number>('ItemWidth', 6);
+    const [ItemWidth, setItemWidth] = useLocalStorage<number>('ItemWidth', 300);
     const [DialogItemWidth, setDialogItemWidth] = useState(ItemWidth);
 
     const handleDialogOpen = () => {


### PR DESCRIPTION
change default manga item width from 6 to 300
will look broken for everyone till they change that setting from 6 to like 200-300

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->