### PR TITLE
use displayValues for select filters

### DIFF
--- a/src/components/source/SourceOptions.tsx
+++ b/src/components/source/SourceOptions.tsx
@@ -88,7 +88,7 @@ export function Options({
                             <SelectFilter
                                 key={`filters ${e.filter.name}`}
                                 name={e.filter.name}
-                                values={e.filter.values}
+                                values={e.filter.displayValues}
                                 state={parseInt(checkif, 10) || e.filter.state as number}
                                 selected={e.filter.selected}
                                 position={index}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -39,6 +39,7 @@ interface ISourceFilter {
     name: string
     state: number | string | boolean | ISourceFilters[] | IState
     values?: string[]
+    displayValues?: string[]
     selected?: ISelected
 }
 


### PR DESCRIPTION
this will fix mangadex filters after tachiyomi changed formats
(will only work for server versions after Syer10's patch to server Suwayomi/Tachidesk-Server#347)
