### PR TITLE
Replace current history instead of pushing on search search

### DIFF
--- a/src/components/util/AppbarSearch.tsx
+++ b/src/components/util/AppbarSearch.tsx
@@ -27,10 +27,10 @@ const AppbarSearch: React.FunctionComponent<IProps> = (props) => {
     const inputRef = React.useRef<HTMLInputElement>();
 
     function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-        setQuery(e.target.value === '' ? undefined : e.target.value);
+        setQuery(e.target.value === '' ? undefined : e.target.value, 'replaceIn');
     }
     const cancelSearch = () => {
-        setQuery(null);
+        setQuery(null, 'replaceIn');
         setSearchOpen(false);
     };
     const handleBlur = () => { if (!query) setSearchOpen(false); };


### PR DESCRIPTION
Currently, each keystroke being made on search would result in a new history entry being pushed, which is unideal, because it means that the back/forward entries are filled up with unnecessary entries. This also affects the app's own back button that is present in some screens, the button would just be undoing what you've typed in search earlier instead of actually going to the previous screen, which is more ideal.

This change makes it so that the current history entry is being replaced instead, using `replaceIn` instead of the default `pushIn` [update type](https://github.com/pbeshai/use-query-params/blob/master/packages/use-query-params/README.md#urlupdatetype).

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->