### PR TITLE
Feature/batch chapter actions

### DIFF
--- a/src/components/manga/SelectionFAB.tsx
+++ b/src/components/manga/SelectionFAB.tsx
@@ -5,6 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import Delete from '@mui/icons-material/Delete';
 import Download from '@mui/icons-material/Download';
 import MoreHoriz from '@mui/icons-material/MoreHoriz';
 import {
@@ -13,10 +14,11 @@ import {
 import { Box } from '@mui/system';
 import { pluralize } from 'components/util/helpers';
 import React, { useRef, useState } from 'react';
+import type { IChapterWithMeta } from './ChapterList';
 
 interface SelectionFABProps{
-    selectedChapters: IChapter[]
-    onAction: (action: 'download') => void
+    selectedChapters: IChapterWithMeta[]
+    onAction: (action: 'download' | 'delete', chapters: IChapterWithMeta[]) => void
 }
 
 const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
@@ -26,6 +28,14 @@ const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
     const anchorEl = useRef<HTMLElement>();
     const [open, setOpen] = useState(false);
     const handleClose = () => setOpen(false);
+
+    const notDownloadedChapters = selectedChapters.filter(
+        ({ chapter, downloadChapter }) => !chapter.downloaded && downloadChapter === undefined,
+    );
+    const notDownloadedCount = notDownloadedChapters.length;
+
+    const downloadedChapters = selectedChapters.filter(({ chapter }) => chapter.downloaded);
+    const downloadedCount = downloadedChapters.length;
 
     return (
         <Box
@@ -55,23 +65,29 @@ const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
                 }}
             >
                 <MenuItem
-                    onClick={() => { onAction('download'); handleClose(); }}
+                    onClick={() => { onAction('download', notDownloadedChapters); handleClose(); }}
+                    disabled={notDownloadedCount === 0}
                 >
                     <ListItemIcon>
                         <Download fontSize="small" />
                     </ListItemIcon>
                     <ListItemText>
                         Download selected
+                        {notDownloadedCount > 0 ? ` (${notDownloadedCount})` : ''}
                     </ListItemText>
                 </MenuItem>
-                {/* <MenuItem onClick={() => { onClearSelection(); handleClose(); }}>
+                <MenuItem
+                    onClick={() => { onAction('delete', downloadedChapters); handleClose(); }}
+                    disabled={downloadedCount === 0}
+                >
                     <ListItemIcon>
-                        <Clear fontSize="small" />
+                        <Delete fontSize="small" />
                     </ListItemIcon>
                     <ListItemText>
-                        ClearSelection
+                        Delete selected
+                        {downloadedCount > 0 ? ` (${downloadedCount})` : ''}
                     </ListItemText>
-                </MenuItem> */}
+                </MenuItem>
             </Menu>
         </Box>
     );

--- a/src/components/manga/SelectionFAB.tsx
+++ b/src/components/manga/SelectionFAB.tsx
@@ -5,20 +5,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import Delete from '@mui/icons-material/Delete';
-import Download from '@mui/icons-material/Download';
 import MoreHoriz from '@mui/icons-material/MoreHoriz';
 import {
-    Fab, ListItemIcon, ListItemText, Menu, MenuItem,
+    Fab, Menu,
 } from '@mui/material';
 import { Box } from '@mui/system';
 import { pluralize } from 'components/util/helpers';
 import React, { useRef, useState } from 'react';
 import type { IChapterWithMeta } from './ChapterList';
+import SelectionFABActionItem from './SelectionFABActionItem';
+
+export type SelectionAction = 'download' | 'delete' | 'bookmark' | 'unbookmark' | 'mark_as_read' | 'mark_as_unread';
 
 interface SelectionFABProps{
     selectedChapters: IChapterWithMeta[]
-    onAction: (action: 'download' | 'delete', chapters: IChapterWithMeta[]) => void
+    onAction: (action: SelectionAction, chapters: IChapterWithMeta[]) => void
 }
 
 const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
@@ -29,13 +30,10 @@ const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
     const [open, setOpen] = useState(false);
     const handleClose = () => setOpen(false);
 
-    const notDownloadedChapters = selectedChapters.filter(
-        ({ chapter, downloadChapter }) => !chapter.downloaded && downloadChapter === undefined,
-    );
-    const notDownloadedCount = notDownloadedChapters.length;
-
-    const downloadedChapters = selectedChapters.filter(({ chapter }) => chapter.downloaded);
-    const downloadedCount = downloadedChapters.length;
+    const handleAction = (action: SelectionAction, chapters: IChapterWithMeta[]) => {
+        onAction(action, chapters);
+        handleClose();
+    };
 
     return (
         <Box
@@ -64,30 +62,44 @@ const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
                     'aria-labelledby': 'selectionMenuButton',
                 }}
             >
-                <MenuItem
-                    onClick={() => { onAction('download', notDownloadedChapters); handleClose(); }}
-                    disabled={notDownloadedCount === 0}
-                >
-                    <ListItemIcon>
-                        <Download fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>
-                        Download selected
-                        {notDownloadedCount > 0 ? ` (${notDownloadedCount})` : ''}
-                    </ListItemText>
-                </MenuItem>
-                <MenuItem
-                    onClick={() => { onAction('delete', downloadedChapters); handleClose(); }}
-                    disabled={downloadedCount === 0}
-                >
-                    <ListItemIcon>
-                        <Delete fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>
-                        Delete selected
-                        {downloadedCount > 0 ? ` (${downloadedCount})` : ''}
-                    </ListItemText>
-                </MenuItem>
+                <SelectionFABActionItem
+                    action="download"
+                    matchingChapters={selectedChapters.filter(
+                        ({ chapter: c, downloadChapter: dc }) => !c.downloaded && dc === undefined,
+                    )}
+                    onClick={handleAction}
+                    title="Download selected"
+                />
+                <SelectionFABActionItem
+                    action="delete"
+                    matchingChapters={selectedChapters.filter(({ chapter }) => chapter.downloaded)}
+                    onClick={handleAction}
+                    title="Delete selected"
+                />
+                <SelectionFABActionItem
+                    action="bookmark"
+                    matchingChapters={selectedChapters.filter(({ chapter }) => !chapter.bookmarked)}
+                    onClick={handleAction}
+                    title="Bookmark selected"
+                />
+                <SelectionFABActionItem
+                    action="unbookmark"
+                    matchingChapters={selectedChapters.filter(({ chapter }) => chapter.bookmarked)}
+                    onClick={handleAction}
+                    title="Remove bookmarks from selected"
+                />
+                <SelectionFABActionItem
+                    action="mark_as_read"
+                    matchingChapters={selectedChapters.filter(({ chapter }) => !chapter.read)}
+                    onClick={handleAction}
+                    title="Mark selected as read"
+                />
+                <SelectionFABActionItem
+                    action="mark_as_unread"
+                    matchingChapters={selectedChapters.filter(({ chapter }) => chapter.read)}
+                    onClick={handleAction}
+                    title="Mark selected as unread"
+                />
             </Menu>
         </Box>
     );

--- a/src/components/manga/SelectionFABActionItem.tsx
+++ b/src/components/manga/SelectionFABActionItem.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import BookmarkAdd from '@mui/icons-material/BookmarkAdd';
+import BookmarkRemove from '@mui/icons-material/BookmarkRemove';
+import Delete from '@mui/icons-material/Delete';
+import Done from '@mui/icons-material/Done';
+import Download from '@mui/icons-material/Download';
+import RemoveDone from '@mui/icons-material/RemoveDone';
+import { ListItemIcon, ListItemText, MenuItem } from '@mui/material';
+import React from 'react';
+import type { IChapterWithMeta } from './ChapterList';
+import type { SelectionAction } from './SelectionFAB';
+
+interface IProps {
+    action: SelectionAction
+    matchingChapters: IChapterWithMeta[]
+    title: string
+    onClick: (action: SelectionAction, chapters: IChapterWithMeta[]) => void
+}
+
+const ICONS = {
+    download: Download,
+    delete: Delete,
+    bookmark: BookmarkAdd,
+    unbookmark: BookmarkRemove,
+    mark_as_read: Done,
+    mark_as_unread: RemoveDone,
+};
+
+const SelectionFABActionItem: React.FC<IProps> = ({
+    action, matchingChapters, onClick, title,
+}) => {
+    const count = matchingChapters.length;
+    const Icon = ICONS[action];
+    return (
+        <MenuItem
+            onClick={() => onClick(action, matchingChapters)}
+            disabled={count === 0}
+        >
+            <ListItemIcon>
+                <Icon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>
+                {title}
+                {count > 0 ? ` (${count})` : ''}
+            </ListItemText>
+        </MenuItem>
+    );
+};
+
+export default SelectionFABActionItem;

--- a/src/components/util/helpers.ts
+++ b/src/components/util/helpers.ts
@@ -12,3 +12,8 @@ export const pluralize = (count: number, input: string | { one: string, many: st
     }
     return input[count === 1 ? 'one' : 'many'];
 };
+
+export const interpolate = (count: number, input: { one: string, many: string }) => {
+    const text = count === 1 ? input.one : input.many;
+    return text.replaceAll('%count%', count.toString());
+};

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -289,3 +289,10 @@ interface LibraryOptions {
     sorts: NullAndUndefined<string>
     sortDesc: NullAndUndefined<boolean>
 }
+
+interface BatchChaptersChange {
+    delete?: boolean
+    isRead?: boolean
+    isBookmarked?: boolean
+    lastPageRead?: number
+}


### PR DESCRIPTION
This PR adds new batch actions to manga chapters.

![image](https://user-images.githubusercontent.com/226277/201980802-74430c4b-e6f2-41f7-8582-7d179a0a2d3b.png)

Options are disabled if no selected chapters match the action.
Number in parentheses indicate how many chapters match given action.
When action is selected, success toast is shown if action is successful.

![image](https://user-images.githubusercontent.com/226277/201981095-931dffef-2801-47d9-aee1-176d9dcc90fc.png)

If there is error, it is shown in toast.

![image](https://user-images.githubusercontent.com/226277/201981286-257a3132-f049-4f65-9750-103656cd3012.png)
