### PR TITLE
Refactor and fix sorting in library

### DIFF
--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -73,6 +73,7 @@ interface IProps {
     manga: IMangaCard
     gridLayout: number | undefined
     dimensions: number
+    inLibraryIndicator?: boolean
 }
 const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) => {
     const {
@@ -82,6 +83,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
         },
         gridLayout,
         dimensions,
+        inLibraryIndicator,
     } = props;
     const { options: { showUnreadBadge, showDownloadBadge } } = useLibraryOptionsContext();
 
@@ -119,7 +121,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                             >
 
                                 <BadgeContainer>
-                                    {inLibrary && (
+                                    {inLibraryIndicator && inLibrary && (
                                         <Typography
                                             sx={{ backgroundColor: 'primary.dark', zIndex: '1' }}
                                         >
@@ -145,7 +147,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                 <SpinnerImage
                                     alt={title}
                                     src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
-                                    imgStyle={inLibrary
+                                    imgStyle={inLibraryIndicator && inLibrary
                                         ? {
                                             height: '100%',
                                             width: '100%',

--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -26,12 +26,14 @@ export interface IMangaGridProps{
     gridLayout?: number | undefined
     horisontal?: boolean | undefined
     noFaces?: boolean | undefined
+    inLibraryIndicator?: boolean
 }
 
-export default function MangaGrid(props: IMangaGridProps) {
+const MangaGrid: React.FC<IMangaGridProps> = (props) => {
     const {
         mangas, isLoading, message, messageExtra,
         hasNextPage, lastPageNum, setLastPageNum, gridLayout, horisontal, noFaces,
+        inLibraryIndicator,
     } = props;
     let mapped;
     const lastManga = useRef<HTMLDivElement>(null);
@@ -90,27 +92,16 @@ export default function MangaGrid(props: IMangaGridProps) {
             );
         }
     } else {
-        mapped = mangas.map((it, idx) => {
-            if (idx === mangas.length - 1) {
-                return (
-                    <MangaCard
-                        key={it.id}
-                        manga={it}
-                        ref={lastManga}
-                        gridLayout={gridLayout}
-                        dimensions={dimensions}
-                    />
-                );
-            }
-            return (
-                <MangaCard
-                    key={it.id}
-                    manga={it}
-                    gridLayout={gridLayout}
-                    dimensions={dimensions}
-                />
-            );
-        });
+        mapped = mangas.map((it, idx) => (
+            <MangaCard
+                key={it.id}
+                manga={it}
+                ref={idx === mangas.length - 1 ? lastManga : undefined}
+                gridLayout={gridLayout}
+                dimensions={dimensions}
+                inLibraryIndicator={inLibraryIndicator}
+            />
+        ));
     }
 
     return (
@@ -135,9 +126,11 @@ export default function MangaGrid(props: IMangaGridProps) {
             </Grid>
         </div>
     );
-}
+};
 
 MangaGrid.defaultProps = {
     message: '',
     messageExtra: undefined,
 };
+
+export default MangaGrid;

--- a/src/components/source/SourceMangaGrid.tsx
+++ b/src/components/source/SourceMangaGrid.tsx
@@ -34,6 +34,7 @@ export default function SourceMangaGrid(props: IMangaGridProps) {
             message={showFilteredOutMessage ? FILTERED_OUT_MESSAGE : message}
             messageExtra={messageExtra}
             gridLayout={gridLayout}
+            inLibraryIndicator
         />
     );
 }

--- a/src/screens/SearchAll.tsx
+++ b/src/screens/SearchAll.tsx
@@ -212,6 +212,7 @@ export default function SearchAll() {
                                 horisontal
                                 noFaces
                                 message={fetched[id] ? 'No manga was found!' : undefined}
+                                inLibraryIndicator
                             />
                         </>
                     )


### PR DESCRIPTION
This PR cleans up code in `LibraryMangaGrid` and changes alphabet sorting to use `localeCompare` instead of equality.

Fixes #188.