### PR TITLE
Hide overflowing text in reader title if text can't be wrapped

### DIFF
--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -203,7 +203,7 @@ export default function ReaderNavBar(props: IProps) {
                                 <KeyboardArrowLeftIcon />
                             </IconButton>
                         )}
-                        <Typography variant="h1">
+                        <Typography variant="h1" textOverflow="ellipsis" overflow="hidden" sx={{ py: 1 }}>
                             {chapter.name}
                         </Typography>
                         <IconButton


### PR DESCRIPTION
This PR fixes the overflowing of chapter title in reader navbar.

![image](https://user-images.githubusercontent.com/226277/203794261-2f880721-0c0d-46a9-84ec-087aa1706532.png)

Fixes #175.