### PR TITLE
Scrolling end detection fix

### DIFF
--- a/src/components/reader/pager/HorizontalPager.tsx
+++ b/src/components/reader/pager/HorizontalPager.tsx
@@ -20,7 +20,13 @@ const findCurrentPageIndex = (wrapper: HTMLDivElement): number => {
     return -1;
 };
 
-const isAtEnd = () => window.innerWidth + window.scrollX >= document.body.scrollWidth;
+const SCROLL_SAFE_ZONE = 5; // px
+const isAtEnd = () => {
+    const visibleEnd = window.innerWidth + window.scrollX;
+    // SCROLL_SAFE_ZONE is here for special cases when window might be .5px shorter
+    // and math just dont add up correctly
+    return visibleEnd >= document.body.scrollWidth - SCROLL_SAFE_ZONE;
+};
 const isAtStart = () => window.scrollX <= 0;
 
 export default function HorizontalPager(props: IReaderProps) {

--- a/src/components/reader/pager/VerticalPager.tsx
+++ b/src/components/reader/pager/VerticalPager.tsx
@@ -21,10 +21,16 @@ const findCurrentPageIndex = (wrapper: HTMLDivElement): number => {
 };
 
 // TODO: make configurable?
+const SCROLL_SAFE_ZONE = 5; // px
 const SCROLL_OFFSET = 0.95;
 const SCROLL_BEHAVIOR: ScrollBehavior = 'smooth';
 
-const isAtBottom = () => window.innerHeight + window.scrollY >= document.body.offsetHeight;
+const isAtBottom = () => {
+    const visibleBottom = window.innerHeight + window.scrollY;
+    // SCROLL_SAFE_ZONE is here for special cases when window might be .5px shorter
+    // and math just dont add up correctly
+    return visibleBottom >= document.body.offsetHeight - SCROLL_SAFE_ZONE;
+};
 const isAtTop = () => window.scrollY <= 0;
 
 export default function VerticalPager(props: IReaderProps) {


### PR DESCRIPTION
This PR fixes weird edge case, where document scrolled all the way to the end, would not get detected as `atEnd`. For some reason there would be 0.5px missing.

This fixes the issue by adding "safe zone" which counts as "atEnd", 5px wide.