### PR TITLE
Refactor/download queue and cleanup visuals overall

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,194 +5,124 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import {
-    BrowserRouter as Router,
-    Switch,
-    Route,
-    Redirect,
-} from 'react-router-dom';
-import { QueryParamProvider } from 'use-query-params';
 import { Container } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
-import {
-    createTheme,
-    ThemeProvider,
-    Theme,
-    StyledEngineProvider,
-} from '@mui/material/styles';
-import { SWRConfig } from 'swr';
-import { fetcher } from 'util/client';
+import AppContext from 'components/context/AppContext';
 import DefaultNavBar from 'components/navbar/DefaultNavBar';
-import DarkTheme from 'components/context/DarkTheme';
-import useLocalStorage from 'util/useLocalStorage';
+import React from 'react';
+import {
+    Redirect, Route, Switch,
+} from 'react-router-dom';
+import Browse from 'screens/Browse';
+import DownloadQueue from 'screens/DownloadQueue';
+import Extensions from 'screens/Extensions';
+import Library from 'screens/Library';
+import Manga from 'screens/Manga';
+import Reader from 'screens/Reader';
+import SearchAll from 'screens/SearchAll';
 import Settings from 'screens/Settings';
 import About from 'screens/settings/About';
-import Categories from 'screens/settings/Categories';
 import Backup from 'screens/settings/Backup';
-import Library from 'screens/Library';
+import Categories from 'screens/settings/Categories';
 import SourceConfigure from 'screens/SourceConfigure';
-import Manga from 'screens/Manga';
 import SourceMangas from 'screens/SourceMangas';
-import Reader from 'screens/Reader';
-import Updates from 'screens/Updates';
-import DownloadQueue from 'screens/DownloadQueue';
-import Browse from 'screens/Browse';
 import Sources from 'screens/Sources';
-import Extensions from 'screens/Extensions';
-import NavBarContextProvider from 'components/navbar/NavBarContextProvider';
-import LibraryOptionsContextProvider from 'components/library/LibraryOptionsProvider';
-import SearchAll from 'screens/SearchAll';
+import Updates from 'screens/Updates';
 
-declare module '@mui/styles/defaultTheme' {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface DefaultTheme extends Theme {}
-}
+const App: React.FC = () => (
+    <AppContext>
+        <CssBaseline />
+        <DefaultNavBar />
+        <Container
+            id="appMainContainer"
+            maxWidth={false}
+            disableGutters
+            sx={{
+                mt: 8,
+                ml: { sm: 8 },
+                mb: { xs: 8, sm: 0 },
+                width: 'auto',
+                overflow: 'auto',
+            }}
+        >
+            <Switch>
+                {/* General Routes */}
+                <Route
+                    exact
+                    path="/"
+                    render={() => (
+                        <Redirect to="/library" />
+                    )}
+                />
+                <Route path="/settings/about">
+                    <About />
+                </Route>
+                <Route path="/settings/categories">
+                    <Categories />
+                </Route>
+                <Route path="/settings/backup">
+                    <Backup />
+                </Route>
+                <Route path="/settings">
+                    <Settings />
+                </Route>
 
-export default function App() {
-    const [darkTheme, setDarkTheme] = useLocalStorage<boolean>(
-        'darkTheme',
-        true,
-    );
+                {/* Manga Routes */}
 
-    const darkThemeContext = {
-        darkTheme,
-        setDarkTheme,
-    };
-
-    const theme = React.useMemo(
-        () => createTheme({
-            palette: {
-                mode: darkTheme ? 'dark' : 'light',
-            },
-            components: {
-                MuiCssBaseline: {
-                    styleOverrides: `
-                        *::-webkit-scrollbar {
-                            width: 10px;
-                            background: ${darkTheme ? '#222' : '#e1e1e1'};   
+                <Route path="/sources/:sourceId/popular/">
+                    <SourceMangas popular />
+                </Route>
+                <Route path="/sources/:sourceId/latest/">
+                    <SourceMangas popular={false} />
+                </Route>
+                <Route path="/sources/:sourceId/configure/">
+                    <SourceConfigure />
+                </Route>
+                <Route path="/sources/all/search/">
+                    <SearchAll />
+                </Route>
+                <Route path="/downloads">
+                    <DownloadQueue />
+                </Route>
+                <Route path="/manga/:mangaId/chapter/:chapterNum">
+                    <></>
+                </Route>
+                <Route path="/manga/:id">
+                    <Manga />
+                </Route>
+                <Route path="/library">
+                    <Library />
+                </Route>
+                <Route path="/updates">
+                    <Updates />
+                </Route>
+                <Route path="/sources">
+                    <Sources />
+                </Route>
+                <Route path="/extensions">
+                    <Extensions />
+                </Route>
+                <Route path="/browse">
+                    <Browse />
+                </Route>
+            </Switch>
+        </Container>
+        <Switch>
+            <Route
+                path="/manga/:mangaId/chapter/:chapterIndex"
+                // passing a key re-mounts the reader
+                // when changing chapters
+                render={(props: any) => (
+                    <Reader
+                        key={
+                            props.match.params
+                                .chapterIndex
                         }
-                        
-                        *::-webkit-scrollbar-thumb {
-                            background: ${darkTheme ? '#111' : '#aaa'};
-                            border-radius: 5px;
-                        }
-                    `,
-                },
-            },
-        }),
-        [darkTheme],
-    );
+                    />
+                )}
+            />
+        </Switch>
+    </AppContext>
+);
 
-    return (
-        <SWRConfig value={{ fetcher }}>
-            <Router>
-                <StyledEngineProvider injectFirst>
-                    <ThemeProvider theme={theme}>
-                        <QueryParamProvider ReactRouterRoute={Route}>
-                            <LibraryOptionsContextProvider>
-                                <NavBarContextProvider>
-                                    <CssBaseline />
-                                    <DefaultNavBar />
-                                    <Container
-                                        id="appMainContainer"
-                                        maxWidth={false}
-                                        disableGutters
-                                        sx={{
-                                            mt: 8,
-                                            ml: { sm: 8 },
-                                            mb: { xs: 8, sm: 0 },
-                                            width: 'auto',
-                                            overflow: 'auto',
-                                        }}
-                                    >
-                                        <Switch>
-                                            {/* General Routes */}
-                                            <Route
-                                                exact
-                                                path="/"
-                                                render={() => (
-                                                    <Redirect to="/library" />
-                                                )}
-                                            />
-                                            <Route path="/settings/about">
-                                                <About />
-                                            </Route>
-                                            <Route path="/settings/categories">
-                                                <Categories />
-                                            </Route>
-                                            <Route path="/settings/backup">
-                                                <Backup />
-                                            </Route>
-                                            <Route path="/settings">
-                                                <DarkTheme.Provider
-                                                    value={darkThemeContext}
-                                                >
-                                                    <Settings />
-                                                </DarkTheme.Provider>
-                                            </Route>
-
-                                            {/* Manga Routes */}
-
-                                            <Route path="/sources/:sourceId/popular/">
-                                                <SourceMangas popular />
-                                            </Route>
-                                            <Route path="/sources/:sourceId/latest/">
-                                                <SourceMangas popular={false} />
-                                            </Route>
-                                            <Route path="/sources/:sourceId/configure/">
-                                                <SourceConfigure />
-                                            </Route>
-                                            <Route path="/sources/all/search/">
-                                                <SearchAll />
-                                            </Route>
-                                            <Route path="/downloads">
-                                                <DownloadQueue />
-                                            </Route>
-                                            <Route path="/manga/:mangaId/chapter/:chapterNum">
-                                                <></>
-                                            </Route>
-                                            <Route path="/manga/:id">
-                                                <Manga />
-                                            </Route>
-                                            <Route path="/library">
-                                                <Library />
-                                            </Route>
-                                            <Route path="/updates">
-                                                <Updates />
-                                            </Route>
-                                            <Route path="/sources">
-                                                <Sources />
-                                            </Route>
-                                            <Route path="/extensions">
-                                                <Extensions />
-                                            </Route>
-                                            <Route path="/browse">
-                                                <Browse />
-                                            </Route>
-                                        </Switch>
-                                    </Container>
-                                    <Switch>
-                                        <Route
-                                            path="/manga/:mangaId/chapter/:chapterIndex"
-                                            // passing a key re-mounts the reader
-                                            // when changing chapters
-                                            render={(props: any) => (
-                                                <Reader
-                                                    key={
-                                                        props.match.params
-                                                            .chapterIndex
-                                                    }
-                                                />
-                                            )}
-                                        />
-                                    </Switch>
-                                </NavBarContextProvider>
-                            </LibraryOptionsContextProvider>
-                        </QueryParamProvider>
-                    </ThemeProvider>
-                </StyledEngineProvider>
-            </Router>
-        </SWRConfig>
-    );
-}
+export default App;

--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -218,7 +218,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                     >
                         <Avatar
                             variant="rounded"
-                            sx={inLibrary
+                            sx={inLibraryIndicator && inLibrary
                                 ? {
                                     width: 56,
                                     height: 56,

--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -37,16 +37,11 @@ const MangaTitle = styled(Typography)({
     position: 'absolute',
     bottom: 0,
     padding: '0.5em',
-    color: 'white',
     fontSize: '1.05rem',
-    textShadow: '0px 0px 3px #000000',
 });
 
 const BadgeContainer = styled('div')({
     display: 'flex',
-    position: 'absolute',
-    top: 5,
-    left: 5,
     height: 'fit-content',
     borderRadius: '5px',
     overflow: 'hidden',
@@ -94,10 +89,9 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
     const mangaLinkTo = { pathname: `/manga/${id}/`, state: { backLink: BACK } };
 
     if (gridLayout !== 2) {
-        const colomns = Math.round(dimensions / ItemWidth);
+        const cols = Math.ceil(dimensions / ItemWidth);
         return (
-            // @ts-ignore gridsize type isnt allowed to be a decimal but it works fine
-            <Grid item xs={12 / colomns} sm={12 / colomns} md={12 / colomns} lg={12 / colomns}>
+            <Grid item columns={cols} xs={1}>
                 <Link to={mangaLinkTo} style={(gridLayout === 1) ? { textDecoration: 'none' } : {}}>
                     <Box
                         sx={{
@@ -107,7 +101,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                     >
                         <Card
                             sx={{
-                            // force standard aspect ratio of manga covers
+                                // force standard aspect ratio of manga covers
                                 aspectRatio: '225/350',
                                 display: 'flex',
                             }}
@@ -120,7 +114,13 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                 }}
                             >
 
-                                <BadgeContainer>
+                                <BadgeContainer
+                                    sx={{
+                                        position: 'absolute',
+                                        top: 5,
+                                        left: 5,
+                                    }}
+                                >
                                     {inLibraryIndicator && inLibrary && (
                                         <Typography
                                             sx={{ backgroundColor: 'primary.dark', zIndex: '1' }}
@@ -173,7 +173,12 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                 {(gridLayout === 1) ? (
                                     <></>
                                 ) : (
-                                    <MangaTitle>
+                                    <MangaTitle
+                                        sx={{
+                                            color: 'white',
+                                            textShadow: '0px 0px 3px #000000',
+                                        }}
+                                    >
                                         {truncateText(title, 61)}
                                     </MangaTitle>
                                 )}
@@ -183,6 +188,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                             <MangaTitle
                                 sx={{
                                     position: 'relative',
+                                    color: 'text.primary',
                                 }}
                             >
                                 {truncateText(title, 61)}
@@ -193,83 +199,82 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
             </Grid>
         );
     }
+
     return (
-        <Grid item xs={12} sm={12} md={12} lg={12}>
-            <Link to={mangaLinkTo} style={{ textDecoration: 'none', color: 'unset' }}>
-                <CardContent sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    padding: 2,
-                    '&:hover': {
-                        backgroundColor: 'action.hover',
-                        transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                    },
-                    '&:active': {
-                        backgroundColor: 'action.selected',
-                        transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                    },
-                    position: 'relative',
-                }}
+        <Grid item xs={12}>
+            <Card>
+                <CardActionArea
+                    component={Link}
+                    to={mangaLinkTo}
                 >
-                    <Avatar
-                        variant="rounded"
-                        sx={inLibrary
-                            ? {
-                                width: 56,
-                                height: 56,
-                                flex: '0 0 auto',
-                                marginRight: 2,
-                                imageRendering: 'pixelated',
-                                filter: 'brightness(0.4)',
-                            }
-                            : {
-                                width: 56,
-                                height: 56,
-                                flex: '0 0 auto',
-                                marginRight: 2,
-                                imageRendering: 'pixelated',
-                            }}
-                        src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
-                    />
-                    <Box
+                    <CardContent
                         sx={{
                             display: 'flex',
-                            flexDirection: 'row',
-                            flexGrow: 1,
-                            width: 'min-content',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            padding: 2,
+                            position: 'relative',
                         }}
                     >
-                        <Typography variant="h5" component="h2">
-                            {truncateText(title, 61)}
-                        </Typography>
-                    </Box>
-                    <BadgeContainer sx={{ position: 'relative' }}>
-                        {inLibrary && (
-                            <Typography
-                                sx={{ backgroundColor: 'primary.dark', zIndex: '1' }}
-                            >
-                                In library
-                            </Typography>
-                        )}
-                        { showUnreadBadge && unread! > 0 && (
-                            <Typography
-                                sx={{ backgroundColor: 'primary.dark' }}
-                            >
-                                {unread}
-                            </Typography>
-                        )}
-                        { showDownloadBadge && downloadCount! > 0 && (
-                            <Typography sx={{
-                                backgroundColor: 'success.dark',
+                        <Avatar
+                            variant="rounded"
+                            sx={inLibrary
+                                ? {
+                                    width: 56,
+                                    height: 56,
+                                    flex: '0 0 auto',
+                                    marginRight: 2,
+                                    imageRendering: 'pixelated',
+                                    filter: 'brightness(0.4)',
+                                }
+                                : {
+                                    width: 56,
+                                    height: 56,
+                                    flex: '0 0 auto',
+                                    marginRight: 2,
+                                    imageRendering: 'pixelated',
+                                }}
+                            src={`${serverAddress}${thumbnailUrl}?useCache=${useCache}`}
+                        />
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                flexGrow: 1,
+                                width: 'min-content',
                             }}
-                            >
-                                {downloadCount}
+                        >
+                            <Typography variant="h5" component="h2">
+                                {truncateText(title, 61)}
                             </Typography>
-                        )}
-                    </BadgeContainer>
-                </CardContent>
-            </Link>
+                        </Box>
+                        <BadgeContainer>
+                            {inLibraryIndicator && inLibrary && (
+                                <Typography
+                                    sx={{ backgroundColor: 'primary.dark' }}
+                                >
+                                    In library
+                                </Typography>
+                            )}
+                            { showUnreadBadge && unread! > 0 && (
+                                <Typography
+                                    sx={{ backgroundColor: 'primary.dark' }}
+                                >
+                                    {unread}
+                                </Typography>
+                            )}
+                            { showDownloadBadge && downloadCount! > 0 && (
+                                <Typography sx={{
+                                    backgroundColor: 'success.dark',
+                                }}
+                                >
+                                    {downloadCount}
+                                </Typography>
+                            )}
+                        </BadgeContainer>
+                    </CardContent>
+                </CardActionArea>
+            </Card>
         </Grid>
     );
 });

--- a/src/components/SourceCard.tsx
+++ b/src/components/SourceCard.tsx
@@ -5,16 +5,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import { CardActionArea } from '@mui/material';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import { useHistory } from 'react-router-dom';
-import Button from '@mui/material/Button';
-import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
-import useLocalStorage from 'util/useLocalStorage';
-import { langCodeToName } from 'util/language';
 import { Box, styled } from '@mui/system';
+import React from 'react';
+import { Link, useHistory } from 'react-router-dom';
+import { langCodeToName } from 'util/language';
+import useLocalStorage from 'util/useLocalStorage';
 
 const MobileWidthButtons = styled('div')(({ theme }) => ({
     display: 'flex',
@@ -38,7 +39,7 @@ interface IProps {
     source: ISource
 }
 
-export default function SourceCard(props: IProps) {
+const SourceCard: React.FC<IProps> = (props: IProps) => {
     const {
         source: {
             id, name, lang, iconUrl, supportsLatest, isNsfw,
@@ -61,82 +62,83 @@ export default function SourceCard(props: IProps) {
         <Card
             sx={{
                 margin: '10px',
-                '&:hover': {
-                    backgroundColor: 'action.hover',
-                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                },
-                '&:active': {
-                    backgroundColor: 'action.selected',
-                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                },
             }}
-            onClick={(e) => redirectTo(e, `/sources/${id}/popular/`)}
         >
-            <CardContent sx={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                padding: 2,
-            }}
+            <CardActionArea
+                component={Link}
+                to={`/sources/${id}/popular/`}
             >
+                <CardContent
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: 2,
+                    }}
+                >
 
-                <Box sx={{ display: 'flex' }}>
-                    <Avatar
-                        variant="rounded"
-                        alt={name}
-                        sx={{
-                            width: 56,
-                            height: 56,
-                            flex: '0 0 auto',
-                            mr: 2,
-                        }}
-                        src={`${serverAddress}${iconUrl}?useCache=${useCache}`}
-                    />
-                    <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-                        <Typography variant="h5" component="h2">
-                            {name}
-                        </Typography>
-                        {id !== '0' && (
-                            <Typography variant="caption" display="block" gutterBottom>
-                                {langCodeToName(lang)}
-                                {isNsfw && (
-                                    <Typography variant="caption" display="inline" gutterBottom color="red">
-                                        {' 18+'}
-                                    </Typography>
-                                )}
+                    <Box sx={{ display: 'flex' }}>
+                        <Avatar
+                            variant="rounded"
+                            alt={name}
+                            sx={{
+                                width: 56,
+                                height: 56,
+                                flex: '0 0 auto',
+                                mr: 2,
+                            }}
+                            src={`${serverAddress}${iconUrl}?useCache=${useCache}`}
+                        />
+                        <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+                            <Typography variant="h5" component="h2">
+                                {name}
                             </Typography>
-                        )}
+                            {id !== '0' && (
+                                <Typography variant="caption" display="block" gutterBottom>
+                                    {langCodeToName(lang)}
+                                    {isNsfw && (
+                                        <Typography variant="caption" display="inline" gutterBottom color="red">
+                                            {' 18+'}
+                                        </Typography>
+                                    )}
+                                </Typography>
+                            )}
+                        </Box>
                     </Box>
-                </Box>
-                <>
-                    <MobileWidthButtons>
-                        {supportsLatest && (
+                    <>
+                        <MobileWidthButtons>
+                            {supportsLatest && (
+                                <Button
+                                    variant="outlined"
+                                    onClick={(e) => redirectTo(e, `/sources/${id}/latest/`)}
+                                >
+                                    Latest
+                                </Button>
+                            )}
+                        </MobileWidthButtons>
+                        <WiderWidthButtons>
+                            {supportsLatest && (
+                                <Button
+                                    component={Link}
+                                    to={`/sources/${id}/latest/`}
+                                    variant="outlined"
+                                >
+                                    Latest
+                                </Button>
+                            )}
                             <Button
+                                component={Link}
+                                to={`/sources/${id}/popular/`}
                                 variant="outlined"
-                                onClick={(e) => redirectTo(e, `/sources/${id}/latest/`)}
                             >
-                                Latest
+                                Browse
                             </Button>
-                        )}
-                    </MobileWidthButtons>
-                    <WiderWidthButtons>
-                        {supportsLatest && (
-                            <Button
-                                variant="outlined"
-                                onClick={(e) => redirectTo(e, `/sources/${id}/latest/`)}
-                            >
-                                Latest
-                            </Button>
-                        )}
-                        <Button
-                            variant="outlined"
-                            onClick={(e: any) => redirectTo(e, `/sources/${id}/popular/`)}
-                        >
-                            Browse
-                        </Button>
-                    </WiderWidthButtons>
-                </>
-            </CardContent>
+                        </WiderWidthButtons>
+                    </>
+                </CardContent>
+            </CardActionArea>
         </Card>
     );
-}
+};
+
+export default SourceCard;

--- a/src/components/context/AppContext.tsx
+++ b/src/components/context/AppContext.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {
+    StyledEngineProvider, ThemeProvider,
+} from '@mui/material/styles';
+import LibraryOptionsContextProvider from 'components/library/LibraryOptionsProvider';
+import NavBarContextProvider from 'components/navbar/NavBarContextProvider';
+import React, { useMemo } from 'react';
+import {
+    BrowserRouter as Router, Route,
+} from 'react-router-dom';
+import { SWRConfig } from 'swr';
+import createTheme from 'theme';
+import { QueryParamProvider } from 'use-query-params';
+import { fetcher } from 'util/client';
+import useLocalStorage from 'util/useLocalStorage';
+import DarkTheme from './DarkTheme';
+
+interface Props {
+    children: React.ReactNode
+}
+
+const AppContext: React.FC<Props> = ({ children }) => {
+    const [darkTheme, setDarkTheme] = useLocalStorage<boolean>(
+        'darkTheme',
+        true,
+    );
+
+    const darkThemeContext = useMemo(() => ({
+        darkTheme,
+        setDarkTheme,
+    }), [darkTheme]);
+
+    const theme = useMemo(
+        () => createTheme(darkTheme),
+        [darkTheme],
+    );
+
+    return (
+        <SWRConfig value={{ fetcher }}>
+            <Router>
+                <StyledEngineProvider injectFirst>
+                    <ThemeProvider theme={theme}>
+                        <DarkTheme.Provider value={darkThemeContext}>
+                            <QueryParamProvider ReactRouterRoute={Route}>
+                                <LibraryOptionsContextProvider>
+                                    <NavBarContextProvider>
+                                        {children}
+                                    </NavBarContextProvider>
+                                </LibraryOptionsContextProvider>
+                            </QueryParamProvider>
+                        </DarkTheme.Provider>
+                    </ThemeProvider>
+                </StyledEngineProvider>
+            </Router>
+        </SWRConfig>
+    );
+};
+
+export default AppContext;

--- a/src/components/manga/ChapterCard.tsx
+++ b/src/components/manga/ChapterCard.tsx
@@ -16,7 +16,7 @@ import Download from '@mui/icons-material/Download';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import RemoveDone from '@mui/icons-material/RemoveDone';
 import {
-    CardActionArea, Checkbox, LinearProgress, ListItemIcon, ListItemText, Stack,
+    CardActionArea, Checkbox, ListItemIcon, ListItemText, Stack,
 } from '@mui/material';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -25,6 +25,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
+import DownloadStateIndicator from 'components/molecules/DownloadStateIndicator';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import client from 'util/client';
@@ -138,9 +139,10 @@ const ChapterCard: React.FC<IProps> = (props: IProps) => {
                             <Typography variant="caption">
                                 {dateStr}
                                 {isDownloaded && ' • Downloaded'}
-                                {dc && ` • Downloading (${(dc.progress * 100).toFixed(2)}%)`}
                             </Typography>
                         </Stack>
+
+                        {dc && <DownloadStateIndicator download={dc} />}
 
                         {selected === null ? (
                             <IconButton aria-label="more" onClick={handleMenuClick} size="large">
@@ -151,16 +153,6 @@ const ChapterCard: React.FC<IProps> = (props: IProps) => {
                         )}
                     </CardContent>
                 </CardActionArea>
-                {dc != null && (
-                    <LinearProgress
-                        sx={{
-                            position: 'absolute', bottom: 0, width: '100%', opacity: 0.5,
-                        }}
-                        variant="determinate"
-                        value={dc.progress * 100}
-                        color="inherit"
-                    />
-                )}
                 <Menu
                     anchorEl={anchorEl}
                     keepMounted

--- a/src/components/manga/ChapterCard.tsx
+++ b/src/components/manga/ChapterCard.tsx
@@ -16,8 +16,7 @@ import Download from '@mui/icons-material/Download';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import RemoveDone from '@mui/icons-material/RemoveDone';
 import {
-    LinearProgress,
-    Checkbox, ListItemIcon, ListItemText, Stack,
+    CardActionArea, Checkbox, LinearProgress, ListItemIcon, ListItemText, Stack,
 } from '@mui/material';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -107,21 +106,12 @@ const ChapterCard: React.FC<IProps> = (props: IProps) => {
                 sx={{
                     position: 'relative',
                     margin: 1,
-                    ':hover': {
-                        backgroundColor: 'action.hover',
-                        transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                        cursor: 'pointer',
-                    },
-                    ':active': {
-                        backgroundColor: 'action.selected',
-                        transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                    },
                 }}
             >
-                <Link
+                <CardActionArea
+                    component={Link}
                     to={{ pathname: `/manga/${chapter.mangaId}/chapter/${chapter.index}`, state: { backLink: BACK } }}
                     style={{
-                        textDecoration: 'none',
                         color: theme.palette.text[chapter.read ? 'disabled' : 'primary'],
                     }}
                     onClick={handleClick}
@@ -160,7 +150,7 @@ const ChapterCard: React.FC<IProps> = (props: IProps) => {
                             <Checkbox checked={selected} />
                         )}
                     </CardContent>
-                </Link>
+                </CardActionArea>
                 {dc != null && (
                     <LinearProgress
                         sx={{

--- a/src/components/manga/ChaptersToolbarMenu.tsx
+++ b/src/components/manga/ChaptersToolbarMenu.tsx
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import FilterList from '@mui/icons-material/FilterList';
-import { Badge, IconButton } from '@mui/material';
+import { IconButton } from '@mui/material';
 import * as React from 'react';
 import ChapterOptions from './ChapterOptions';
 import { isFilterActive } from './util';
@@ -23,9 +23,7 @@ const ChaptersToolbarMenu = ({ options, optionsDispatch }: IProps) => {
     return (
         <>
             <IconButton onClick={() => setOpen(true)}>
-                <Badge color="primary" variant="dot" invisible={!isFiltered}>
-                    <FilterList />
-                </Badge>
+                <FilterList color={isFiltered ? 'warning' : undefined} />
             </IconButton>
             <ChapterOptions
                 open={open}

--- a/src/components/molecules/DownloadStateIndicator.tsx
+++ b/src/components/molecules/DownloadStateIndicator.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { CircularProgress } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import { Box } from '@mui/system';
+import React from 'react';
+
+interface DownloadStateIndicatorProps {
+    download: IDownloadChapter
+}
+
+const DownloadStateIndicator: React.FC<DownloadStateIndicatorProps> = ({ download }) => (
+    <Box
+        sx={{
+            position: 'relative',
+            display: 'inline-flex',
+            width: '50px',
+            justifyContent: 'center',
+        }}
+    >
+        {download.progress !== 0 && (
+            <CircularProgress
+                variant="determinate"
+                value={download.progress * 100}
+            />
+        )}
+        <Box
+            sx={{
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: 0,
+                position: 'absolute',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}
+        >
+            <Typography variant="caption" component="div" color="text.secondary">
+                {download.progress !== 0 && `${Math.round(download.progress * 100)}%`}
+                {download.progress === 0 && download.state}
+            </Typography>
+        </Box>
+    </Box>
+);
+
+export default DownloadStateIndicator;

--- a/src/components/navbar/DefaultNavBar.tsx
+++ b/src/components/navbar/DefaultNavBar.tsx
@@ -25,7 +25,6 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 import { Link, useHistory } from 'react-router-dom';
 import NavBarContext from 'components/context/NavbarContext';
-import DarkTheme from 'components/context/DarkTheme';
 import ExtensionOutlinedIcon from 'components/util/CustomExtensionOutlinedIcon';
 import { Box } from '@mui/system';
 import { createPortal } from 'react-dom';
@@ -82,7 +81,6 @@ const navbarItems: Array<NavbarItem> = [
 export default function DefaultNavBar() {
     const { title, action, override } = useContext(NavBarContext);
     const backTo = useBackTo();
-    const { darkTheme } = useContext(DarkTheme);
 
     const theme = useTheme();
     const history = useHistory();
@@ -109,7 +107,7 @@ export default function DefaultNavBar() {
 
     return (
         <Box sx={{ flexGrow: 1 }}>
-            <AppBar position="fixed" color={darkTheme ? 'default' : 'primary'}>
+            <AppBar position="fixed" color="default">
                 <Toolbar>
                     {!isMainRoute && (
                         <IconButton

--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -17,7 +17,7 @@ import { useHistory, Link } from 'react-router-dom';
 import Slide from '@mui/material/Slide';
 import Fade from '@mui/material/Fade';
 import Zoom from '@mui/material/Zoom';
-import { Switch } from '@mui/material';
+import { Divider, Switch } from '@mui/material';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import MenuItem from '@mui/material/MenuItem';
@@ -61,12 +61,6 @@ const Root = styled('div')(({ theme }) => ({
             fontSize: '1.25rem',
             flexGrow: 1,
         },
-    },
-    '& hr': {
-        margin: '0 16px',
-        height: '1px',
-        border: '0',
-        backgroundColor: theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],
     },
 }));
 
@@ -312,7 +306,7 @@ export default function ReaderNavBar(props: IProps) {
                             </ListItem>
                         </List>
                     </Collapse>
-                    <hr />
+                    <Divider sx={{ my: 1, mx: 2 }} />
                     <Navigation>
                         <span>
                             {`Currently on page ${curPage + 1} of ${chapter.pageCount}`}

--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -39,8 +39,7 @@ const Root = styled('div')(({ theme }) => ({
     backgroundColor: theme.palette.background.default,
 
     '& header': {
-        backgroundColor:
-        theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],
+        backgroundColor: theme.palette.action.hover,
         display: 'flex',
         alignItems: 'center',
         minHeight: '64px',
@@ -106,9 +105,9 @@ const OpenDrawerButton = styled(IconButton)(({ theme }) => ({
     height: '40px',
     width: '40px',
     borderRadius: 5,
-    backgroundColor: theme.palette.mode === 'dark' ? 'black' : 'white',
+    backgroundColor: theme.palette.custom.main,
     '&:hover': {
-        backgroundColor: theme.palette.mode === 'dark' ? theme.palette.grey[900] : theme.palette.grey[100],
+        backgroundColor: theme.palette.custom.light,
     },
 }));
 
@@ -357,7 +356,6 @@ export default function ReaderNavBar(props: IProps) {
                 <Fade in={!hideOpenButton}>
                     <OpenDrawerButton
                         edge="start"
-                        color="inherit"
                         aria-label="menu"
                         disableRipple
                         disableFocusRipple

--- a/src/components/navbar/navigation/DesktopSideBar.tsx
+++ b/src/components/navbar/navigation/DesktopSideBar.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '@mui/material/styles';
 const SideNavBarContainer = styled('div')(({ theme }) => ({
     height: '100vh',
     width: theme.spacing(8),
-    backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[900],
+    backgroundColor: theme.palette.custom,
     position: 'fixed',
     top: 0,
     left: 0,

--- a/src/components/navbar/navigation/MobileBottomBar.tsx
+++ b/src/components/navbar/navigation/MobileBottomBar.tsx
@@ -16,7 +16,7 @@ const BottomNavContainer = styled('div')(({ theme }) => ({
     left: 0,
     height: theme.spacing(7),
     width: '100vw',
-    backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[900],
+    backgroundColor: theme.palette.custom.light,
     position: 'fixed',
     display: 'flex',
     flexDirection: 'row',

--- a/src/screens/DownloadQueue.tsx
+++ b/src/screens/DownloadQueue.tsx
@@ -7,50 +7,38 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import NavbarContext from 'components/context/NavbarContext';
-import React, { useContext, useEffect } from 'react';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import PauseIcon from '@mui/icons-material/Pause';
-import IconButton from '@mui/material/IconButton';
 import DeleteIcon from '@mui/icons-material/Delete';
-import client from 'util/client';
+import DragHandle from '@mui/icons-material/DragHandle';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import {
-    DragDropContext, Draggable, DraggingStyle, Droppable, DropResult, NotDraggingStyle,
-} from 'react-beautiful-dnd';
-import { useTheme, Palette } from '@mui/material/styles';
-import List from '@mui/material/List';
-import DragHandleIcon from '@mui/icons-material/DragHandle';
-import ListItem from '@mui/material/ListItem';
-import { ListItemIcon } from '@mui/material';
+    Card, CardActionArea, Stack,
+} from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+import NavbarContext from 'components/context/NavbarContext';
 import EmptyView from 'components/util/EmptyView';
+import React, { useContext, useEffect } from 'react';
+import {
+    DragDropContext, Draggable, Droppable, DropResult,
+} from 'react-beautiful-dnd';
+import client from 'util/client';
 
-import { Box } from '@mui/system';
 import Typography from '@mui/material/Typography';
-import { useHistory } from 'react-router-dom';
+import { Box } from '@mui/system';
 import useSubscription from 'components/library/useSubscription';
-
-const getItemStyle = (isDragging: boolean,
-    draggableStyle: DraggingStyle | NotDraggingStyle | undefined, palette: Palette) => ({
-    // styles we need to apply on draggables
-    ...draggableStyle,
-
-    ...(isDragging && {
-        background: palette.mode === 'dark' ? '#424242' : 'rgb(235,235,235)',
-    }),
-});
+import DownloadStateIndicator from 'components/molecules/DownloadStateIndicator';
+import { NavbarToolbar } from 'components/navbar/DefaultNavBar';
+import { Link } from 'react-router-dom';
+import { BACK } from 'util/useBackTo';
 
 const initialQueue = {
     status: 'Stopped',
     queue: [],
 } as IQueue;
 
-export default function DownloadQueue() {
+const DownloadQueue: React.FC = () => {
     const { data: queueState } = useSubscription<IQueue>('/api/v1/downloads');
     const { queue, status } = queueState ?? initialQueue;
-
-    const history = useHistory();
-
-    const theme = useTheme();
 
     const { setTitle, setAction } = useContext(NavbarContext);
 
@@ -64,22 +52,8 @@ export default function DownloadQueue() {
 
     useEffect(() => {
         setTitle('Download Queue');
-
-        setAction(() => {
-            if (status === 'Stopped') {
-                return (
-                    <IconButton onClick={toggleQueueStatus} size="large">
-                        <PlayArrowIcon />
-                    </IconButton>
-                );
-            }
-            return (
-                <IconButton onClick={toggleQueueStatus} size="large">
-                    <PauseIcon />
-                </IconButton>
-            );
-        });
-    }, [status]);
+        setAction(null);
+    }, []);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const onDragEnd = (result: DropResult) => {
@@ -89,27 +63,29 @@ export default function DownloadQueue() {
         return <EmptyView message="No downloads" />;
     }
 
-    const callDeleteServer = (chapter: IChapter) => {
-        // remove from download queue
-        client.delete(`/api/v1/download/${chapter.mangaId}/chapter/${chapter.index}`);
-
-        // delete partial download, should be handle server side?
-        // bug: The folder and the last image downloaded are not deleted
-        client.delete(`/api/v1/manga/${chapter.mangaId}/chapter/${chapter.index}`);
-    };
-
-    const deleteChapterQueue = (chapter: IChapter) => {
+    const handleDelete = (chapter: IChapter) => {
         // required to stop before deleting otherwise the download kept going. Server issue?
         client.get('/api/v1/downloads/stop')
-            .then(() => callDeleteServer(chapter));
+            .then(() => Promise.all([
+                // remove from download queue
+                client.delete(`/api/v1/download/${chapter.mangaId}/chapter/${chapter.index}`),
+                // delete partial download, should be handle server side?
+                // bug: The folder and the last image downloaded are not deleted
+                client.delete(`/api/v1/manga/${chapter.mangaId}/chapter/${chapter.index}`),
+            ]));
     };
 
     return (
         <>
+            <NavbarToolbar>
+                <IconButton onClick={toggleQueueStatus} size="large">
+                    {status === 'Stopped' ? <PlayArrowIcon /> : <PauseIcon />}
+                </IconButton>
+            </NavbarToolbar>
             <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="droppable">
                     {(provided) => (
-                        <List ref={provided.innerRef}>
+                        <Box ref={provided.innerRef} sx={{ pt: 1 }}>
                             {queue.map((item, index) => (
                                 <Draggable
                                     key={`${item.mangaId}-${item.chapterIndex}`}
@@ -117,72 +93,57 @@ export default function DownloadQueue() {
                                     index={index}
                                 >
                                     {(provided, snapshot) => (
-                                        <ListItem
-                                            ContainerProps={{ ref: provided.innerRef } as any}
-                                            sx={{
-                                                display: 'flex',
-                                                justifyContent: 'flex-start',
-                                                alignItems: 'flex-start',
-                                                padding: 2,
-                                                margin: '10px',
-                                                '&:hover': {
-                                                    backgroundColor: 'action.hover',
-                                                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                                                },
-                                                '&:active': {
-                                                    backgroundColor: 'action.selected',
-                                                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                                                },
-                                            }}
-                                            onClick={() => history.push(`/manga/${item.chapter.mangaId}`)}
+                                        <Box
                                             {...provided.draggableProps}
                                             {...provided.dragHandleProps}
-                                            style={getItemStyle(
-                                                snapshot.isDragging,
-                                                provided.draggableProps.style,
-                                                theme.palette,
-                                            )}
                                             ref={provided.innerRef}
+                                            sx={{ p: 1, pb: 2 }}
                                         >
-                                            <ListItemIcon sx={{ margin: 'auto 0' }}>
-                                                <DragHandleIcon />
-                                            </ListItemIcon>
-                                            <Box sx={{ display: 'flex' }}>
-                                                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                                                    <Typography variant="h5" component="h2">
-                                                        {item.manga.title}
-                                                    </Typography>
-                                                    <Typography variant="caption" display="block" gutterBottom>
-                                                        {`${item.chapter.name} `
-                                                        + `(${(item.progress * 100).toFixed(2)}%)`
-                                                        + ` => state: ${item.state}`}
-                                                    </Typography>
-                                                </Box>
-                                            </Box>
-                                            <IconButton
-                                                sx={{ marginLeft: 'auto' }}
-                                                onClick={(e) => {
-                                                    // deleteCategory(index);
-                                                    // prevent parent tags from getting the event
-                                                    e.stopPropagation();
-
-                                                    // delete chapter from download queue
-                                                    deleteChapterQueue(item.chapter);
+                                            <Card
+                                                sx={{
+                                                    backgroundColor: snapshot.isDragging ? 'custom.light' : undefined,
                                                 }}
-                                                size="large"
                                             >
-                                                <DeleteIcon />
-                                            </IconButton>
-                                        </ListItem>
+                                                <CardActionArea
+                                                    component={Link}
+                                                    to={{ pathname: `/manga/${item.chapter.mangaId}`, state: { backLink: BACK } }}
+                                                    sx={{ display: 'flex', alignItems: 'center', p: 1 }}
+                                                >
+                                                    <IconButton sx={{ pointerEvents: 'none' }}>
+                                                        <DragHandle />
+                                                    </IconButton>
+                                                    <Stack sx={{ flex: 1, ml: 1 }} direction="column">
+                                                        <Typography variant="h6">
+                                                            {item.manga.title}
+                                                        </Typography>
+                                                        <Typography variant="caption" display="block" gutterBottom>
+                                                            {item.chapter.name}
+                                                        </Typography>
+                                                    </Stack>
+                                                    <DownloadStateIndicator download={item} />
+                                                    <IconButton
+                                                        onClick={(e) => {
+                                                            e.preventDefault();
+                                                            e.stopPropagation();
+                                                            handleDelete(item.chapter);
+                                                        }}
+                                                        size="large"
+                                                    >
+                                                        <DeleteIcon />
+                                                    </IconButton>
+                                                </CardActionArea>
+                                            </Card>
+                                        </Box>
                                     )}
                                 </Draggable>
-
                             ))}
                             {provided.placeholder}
-                        </List>
+                        </Box>
                     )}
                 </Droppable>
             </DragDropContext>
         </>
     );
-}
+};
+
+export default DownloadQueue;

--- a/src/screens/Extensions.tsx
+++ b/src/screens/Extensions.tsx
@@ -185,7 +185,6 @@ export default function MangaExtensions() {
                                     paddingLeft: 25,
                                     paddingBottom: '0.83em',
                                     paddingTop: '0.83em',
-                                    backgroundColor: 'rgb(18, 18, 18)',
                                     fontSize: '2em',
                                     fontWeight: 'bold',
                                 }}

--- a/src/screens/SearchAll.tsx
+++ b/src/screens/SearchAll.tsx
@@ -6,20 +6,20 @@
 * file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
-import { Card } from '@mui/material';
-import { useHistory } from 'react-router-dom';
+import { Card, CardActionArea, Typography } from '@mui/material';
 import NavbarContext from 'components/context/NavbarContext';
 import MangaGrid from 'components/MangaGrid';
 import LangSelect from 'components/navbar/action/LangSelect';
 import AppbarSearch from 'components/util/AppbarSearch';
+import PQueue from 'p-queue/dist/index';
 import React, { useContext, useEffect, useState } from 'react';
-import { useQueryParam, StringParam } from 'use-query-params';
+import { Link } from 'react-router-dom';
+import { StringParam, useQueryParam } from 'use-query-params';
 import client from 'util/client';
 import {
     langCodeToName, langSortCmp, sourceDefualtLangs, sourceForcedDefaultLangs,
 } from 'util/language';
 import useLocalStorage from 'util/useLocalStorage';
-import PQueue from 'p-queue/dist/index';
 
 function sourceToLangList(sources: ISource[]) {
     const result: string[] = [];
@@ -32,7 +32,7 @@ function sourceToLangList(sources: ISource[]) {
     return result;
 }
 
-export default function SearchAll() {
+const SearchAll: React.FC = () => {
     const [query] = useQueryParam('query', StringParam);
     const { setTitle, setAction } = useContext(NavbarContext);
     const [triggerUpdate, setTriggerUpdate] = useState<number>(2);
@@ -150,14 +150,6 @@ export default function SearchAll() {
         );
     }, [shownLangs, sources]);
 
-    const history = useHistory();
-
-    const redirectTo = (e: any, to: string) => {
-        history.push(to);
-
-        // prevent parent tags from getting the event
-        e.stopPropagation();
-    };
     if (query) {
         return (
             <>
@@ -177,31 +169,19 @@ export default function SearchAll() {
                 }).map(({ lang, id, displayName }) => (
                     (
                         <>
-                            <Card
-                                sx={{
-                                    margin: '10px',
-                                    '&:hover': {
-                                        backgroundColor: 'action.hover',
-                                        transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                                    },
-                                    '&:active': {
-                                        backgroundColor: 'action.selected',
-                                        transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                                    },
-                                }}
-                                onClick={(e) => redirectTo(e, `/sources/${id}/popular/?R&query=${query}`)}
-                            >
-                                <h1
-                                    key={lang}
-                                    style={{ margin: '25px 0px 0px 25px' }}
+                            <Card sx={{ margin: '10px' }}>
+                                <CardActionArea
+                                    component={Link}
+                                    to={`/sources/${id}/popular/?R&query=${query}`}
+                                    sx={{ p: 3 }}
                                 >
-                                    {displayName}
-                                </h1>
-                                <p
-                                    style={{ margin: '0px 0px 25px 25px' }}
-                                >
-                                    {langCodeToName(lang)}
-                                </p>
+                                    <Typography variant="h5">
+                                        {displayName}
+                                    </Typography>
+                                    <Typography variant="caption">
+                                        {langCodeToName(lang)}
+                                    </Typography>
+                                </CardActionArea>
                             </Card>
                             <MangaGrid
                                 mangas={mangas[id] || []}
@@ -222,4 +202,6 @@ export default function SearchAll() {
         );
     }
     return (<></>);
-}
+};
+
+export default SearchAll;

--- a/src/screens/Updates.tsx
+++ b/src/screens/Updates.tsx
@@ -5,22 +5,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import React, {
-    useContext, useEffect, useState, useRef,
-} from 'react';
-import { useHistory } from 'react-router-dom';
+import DownloadIcon from '@mui/icons-material/Download';
+import { CardActionArea } from '@mui/material';
+import Avatar from '@mui/material/Avatar';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import IconButton from '@mui/material/IconButton';
-import DownloadIcon from '@mui/icons-material/Download';
-import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
+import { Box } from '@mui/system';
 import NavbarContext from 'components/context/NavbarContext';
-import client from 'util/client';
-import useLocalStorage from 'util/useLocalStorage';
 import EmptyView from 'components/util/EmptyView';
 import LoadingPlaceholder from 'components/util/LoadingPlaceholder';
-import { Box } from '@mui/system';
+import React, {
+    useContext, useEffect, useRef, useState,
+} from 'react';
+import { Link, useHistory } from 'react-router-dom';
+import client from 'util/client';
+import useLocalStorage from 'util/useLocalStorage';
 
 function epochToDate(epoch: number) {
     const date = new Date(0); // The 0 there is the key, which sets the date to the epoch
@@ -67,7 +68,7 @@ const initialQueue = {
     queue: [],
 } as IQueue;
 
-export default function Updates() {
+const Updates: React.FC = () => {
     const history = useHistory();
 
     const { setTitle, setAction } = useContext(NavbarContext);
@@ -170,49 +171,43 @@ export default function Updates() {
                         <Card
                             ref={globalIdx === updateEntries.length - 1 ? lastEntry : undefined}
                             key={globalIdx}
-                            sx={{
-                                margin: '10px',
-                                '&:hover': {
-                                    backgroundColor: 'action.hover',
-                                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                                },
-                                '&:active': {
-                                    backgroundColor: 'action.selected',
-                                    transition: 'background-color 100ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-                                },
-                            }}
-                            onClick={() => history.push({ pathname: `/manga/${chapter.mangaId}/chapter/${chapter.index}`, state: history.location.state })}
+                            sx={{ margin: '10px' }}
                         >
-                            <CardContent sx={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                                padding: 2,
-                            }}
+                            <CardActionArea
+                                component={Link}
+                                to={{ pathname: `/manga/${chapter.mangaId}/chapter/${chapter.index}`, state: history.location.state }}
                             >
-                                <Box sx={{ display: 'flex' }}>
-                                    <Avatar
-                                        variant="rounded"
-                                        sx={{
-                                            width: 56,
-                                            height: 56,
-                                            flex: '0 0 auto',
-                                            marginRight: 2,
-                                            imageRendering: 'pixelated',
-                                        }}
-                                        src={`${serverAddress}${manga.thumbnailUrl}?useCache=${useCache}`}
-                                    />
-                                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                                        <Typography variant="h5" component="h2">
-                                            {manga.title}
-                                        </Typography>
-                                        <Typography variant="caption" display="block" gutterBottom>
-                                            {chapter.name}
-                                            {downloadStatusStringFor(chapter)}
-                                        </Typography>
+                                <CardContent
+                                    sx={{
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                        alignItems: 'center',
+                                        padding: 2,
+                                    }}
+                                >
+                                    <Box sx={{ display: 'flex' }}>
+                                        <Avatar
+                                            variant="rounded"
+                                            sx={{
+                                                width: 56,
+                                                height: 56,
+                                                flex: '0 0 auto',
+                                                marginRight: 2,
+                                                imageRendering: 'pixelated',
+                                            }}
+                                            src={`${serverAddress}${manga.thumbnailUrl}?useCache=${useCache}`}
+                                        />
+                                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                                            <Typography variant="h5" component="h2">
+                                                {manga.title}
+                                            </Typography>
+                                            <Typography variant="caption" display="block" gutterBottom>
+                                                {chapter.name}
+                                                {downloadStatusStringFor(chapter)}
+                                            </Typography>
+                                        </Box>
                                     </Box>
-                                </Box>
-                                {downloadStatusStringFor(chapter) === ''
+                                    {downloadStatusStringFor(chapter) === ''
                                         && (
                                             <IconButton
                                                 onClick={(e) => {
@@ -225,11 +220,14 @@ export default function Updates() {
                                                 <DownloadIcon />
                                             </IconButton>
                                         )}
-                            </CardContent>
+                                </CardContent>
+                            </CardActionArea>
                         </Card>
                     ))}
                 </div>
             ))}
         </>
     );
-}
+};
+
+export default Updates;

--- a/src/screens/Updates.tsx
+++ b/src/screens/Updates.tsx
@@ -201,20 +201,19 @@ const Updates: React.FC = () => {
                                                 </Typography>
                                             </Box>
                                         </Box>
-                                        {download
-                                            ? <DownloadStateIndicator download={download} />
-                                            : (
-                                                <IconButton
-                                                    onClick={(e) => {
-                                                        e.stopPropagation();
-                                                        e.preventDefault();
-                                                        downloadChapter(chapter);
-                                                    }}
-                                                    size="large"
-                                                >
-                                                    <DownloadIcon />
-                                                </IconButton>
-                                            )}
+                                        {download && <DownloadStateIndicator download={download} />}
+                                        {download == null && !chapter.downloaded && (
+                                            <IconButton
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    e.preventDefault();
+                                                    downloadChapter(chapter);
+                                                }}
+                                                size="large"
+                                            >
+                                                <DownloadIcon />
+                                            </IconButton>
+                                        )}
                                     </CardContent>
                                 </CardActionArea>
                             </Card>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { Theme, createTheme as createMuiTheme } from '@mui/material/styles';
+
+declare module '@mui/styles/defaultTheme' {
+    interface DefaultTheme extends Theme {}
+}
+
+declare module '@mui/material/styles' {
+    interface PaletteOptions {
+        custom?: PaletteOptions['primary'];
+    }
+
+}
+
+const createTheme = (dark?: boolean) => {
+    const baseTheme = createMuiTheme({
+        palette: {
+            mode: dark ? 'dark' : 'light',
+        },
+    });
+
+    const tachideskTheme = createMuiTheme({
+        palette: {
+            custom: {
+                main: dark ? baseTheme.palette.common.black : baseTheme.palette.common.white,
+                light: dark ? baseTheme.palette.grey[900] : baseTheme.palette.grey[100],
+            },
+        },
+        components: {
+            MuiCssBaseline: {
+                styleOverrides: `
+                *::-webkit-scrollbar {
+                    width: 10px;
+                    background: ${dark ? '#222' : '#e1e1e1'};   
+                }
+                
+                *::-webkit-scrollbar-thumb {
+                    background: ${dark ? '#111' : '#aaa'};
+                    border-radius: 5px;
+                }
+            `,
+            },
+        },
+    }, baseTheme);
+
+    return tachideskTheme;
+};
+
+export default createTheme;


### PR DESCRIPTION
This PR started as download queue update, but ended up with some more cleanup.

I have moved all the app contexts and stuff to separate component so that routes do not end up intended 100 spaces. The new component is called `AppContext`. I have also moved theme creation to separate file and added new custom color with values for cases when solid color is needed, that is different then basic background color.

With new custom color, I have replaced usage of `theme.palette.mode === 'dark'` for determining background color. This fixed background color of some components that were currently incorrect in light mode. I have also used focused background color instead of some custom colors.

Some of the changes (I might have missed some for screenshots):

Reader navbar background (divider was changed from hr to `Divider`)
![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204056088-97faf585-10d9-4858-ac1f-ec0070ae31bf.png)

Hover state
![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204056058-15b780e9-ec08-4d6c-b944-dd103f1c9f62.png)

Extensions list
![Tachidesk_and_Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204058552-0fe145b1-2160-4825-a393-ddef9d3c18e1.png)

I have changed different clickable element styles for cards with `CardActionArea` to unify looks. Another benefit is that all the items are now links, so things like middle mouse click will work as intended.

Library
![Tachidesk_and_Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204056845-17fe70a7-e1b5-4fca-b126-ef92a3409d0e.png)

![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204057087-93cb18e2-fe2f-4b54-b57d-ea2a523c51f1.png)

Sources

![Tachidesk_and_Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204057220-5da87265-c398-4637-982a-b4ccb5d2b0ab.png)

![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204057201-d0e294cb-8511-43b6-be93-7577d9aa8cf9.png)

Search All
![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204058028-26dc65d1-86fe-4dde-88cb-1b1aa8581e55.png)

Updates (new download progress is visible, more below)
![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204057741-59735be5-5918-48e6-b007-040e49f6a1c7.png)

I have also fixed manga card title color to work correctly in light theme comfortable layout

![Tachidesk_and_Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204057926-83d568c4-3c3b-40c9-8f7e-5397b4e80881.png)

Download queue was refactored and cleaned up. It now also uses Cards with `CardActiveArea` for items. New `DownloadStateIndicator` was added to better indicate download state and progress. It was also used in Updates screen (see above) and ChapterList in Manga screen.

![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204058268-a8c57312-9daf-4ab7-97d2-7d9da0472eeb.png)

(chapter list filter icon was also changed back to `warn` color instead of badge when filtering is active)
![Tachidesk_and_Tachidesk](https://user-images.githubusercontent.com/226277/204058355-fa932038-159f-485d-a7aa-c700d7e10b5b.png)

This doesn't fix anything, it is just cleanup and code improvement.