### PR TITLE
Fix "back" pagination on double page layout in reader for spread pages

### DIFF
--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -19,11 +19,14 @@ const isSpreadPage = (image: HTMLImageElement): boolean => {
 const isSinglePage = (index: number, spreadPages: boolean[]): boolean => {
     // Page is single if it is spread page
     if (spreadPages[index]) return true;
+    // Page is single if it is last page
+    if (index === spreadPages.length - 1) return true;
     // Page can not be single if it is not followed by spread
     if (!spreadPages[index + 1]) return false;
     // Page is single if number of single pages since last spread is odd
     const previousSpreadIndex = spreadPages.lastIndexOf(true, index - 1);
-    return (spreadPages.slice(previousSpreadIndex, index).filter((v) => !v).length % 2) === 0;
+    const numberOfNonSpreads = index - (previousSpreadIndex + 1);
+    return numberOfNonSpreads % 2 === 0;
 };
 
 export default function DoublePagedPager(props: IReaderProps) {
@@ -81,9 +84,17 @@ export default function DoublePagedPager(props: IReaderProps) {
     }
 
     function pagesToGoBack() {
-        if (isSinglePage(curPage - 1, spreadPage.current)) {
+        // If previous page is single page, go only one page pack
+        // If previous page is not single page, but we are on last page
+        // go back one page anyway.
+        // This handles special case, where last page was displayed in pair, but then
+        // page was changed to the last page and now it is shown as single page.
+        const isLastPage = curPage === spreadPage.current.length - 1;
+        if (isSinglePage(curPage - 1, spreadPage.current) || isLastPage) {
             return 1;
         }
+
+        // Otherwise go two pages back
         return 2;
     }
 


### PR DESCRIPTION
This PR fixes #181

There is new cache array (`spreadPage`) for storing which pages are spreads and which are regular single pages. When "back" navigation is called, new function now checks if the previous page should be single page or double page.

I have left comments in the code to make it clear how the logic is meant to work.
