### PR TITLE
refresh Library after a update

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -79,18 +79,18 @@ const sortManga = (
     return result;
 };
 
-const LibraryMangaGrid: React.FC<IMangaGridProps> = ({
-    mangas, isLoading, hasNextPage, lastPageNum, setLastPageNum, message,
+const LibraryMangaGrid: React.FC<IMangaGridProps & { lastLibraryUpdate: number }> = ({
+    mangas, isLoading, hasNextPage, lastPageNum, setLastPageNum, message, lastLibraryUpdate,
 }) => {
     const [query] = useQueryParam('query', StringParam);
     const { options } = useLibraryOptionsContext();
     const { unread, downloaded } = options;
 
     const sortedManga = useMemo(() => sortManga(mangas, options.sorts, options.sortDesc),
-        [mangas, options.sorts, options.sortDesc]);
+        [mangas, lastLibraryUpdate, options.sorts, options.sortDesc]);
 
     const filteredManga = useMemo(() => filterManga(sortedManga, query, unread, downloaded),
-        [sortedManga, query, unread, downloaded]);
+        [sortedManga, lastLibraryUpdate, query, unread, downloaded]);
 
     const showFilteredOutMessage = (unread != null || downloaded != null || query)
         && filteredManga.length === 0 && mangas.length > 0;

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -21,6 +21,7 @@ import { useQuery } from 'util/client';
 import UpdateChecker from '../components/library/UpdateChecker';
 
 export default function Library() {
+    const [lastLibraryUpdate, setLastLibraryUpdate] = useState(Date.now());
     const { data: tabsData, error: tabsError, loading } = useQuery<ICategory[]>('/api/v1/category');
     const tabs = tabsData ?? [];
 
@@ -43,7 +44,7 @@ export default function Library() {
             <>
                 <AppbarSearch />
                 <LibraryToolbarMenu />
-                <UpdateChecker />
+                <UpdateChecker handleFinishedUpdate={setLastLibraryUpdate} />
             </>,
         );
         return () => {
@@ -76,6 +77,7 @@ export default function Library() {
         return (
             <LibraryMangaGrid
                 mangas={mangas}
+                lastLibraryUpdate={lastLibraryUpdate}
                 hasNextPage={false}
                 lastPageNum={lastPageNum}
                 setLastPageNum={setLastPageNum}
@@ -114,6 +116,7 @@ export default function Library() {
                         : (
                             <LibraryMangaGrid
                                 mangas={mangas}
+                                lastLibraryUpdate={lastLibraryUpdate}
                                 hasNextPage={false}
                                 lastPageNum={lastPageNum}
                                 setLastPageNum={setLastPageNum}


### PR DESCRIPTION
Library had to be refreshed manually to see the latest manga updates.

Closes #211 