### PR TITLE
Add Tooltip containing full manga title to titles in library

### DIFF
--- a/src/components/MangaCard.tsx
+++ b/src/components/MangaCard.tsx
@@ -178,6 +178,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                             color: 'white',
                                             textShadow: '0px 0px 3px #000000',
                                         }}
+                                        title={title}
                                     >
                                         {truncateText(title, 61)}
                                     </MangaTitle>
@@ -190,6 +191,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                     position: 'relative',
                                     color: 'text.primary',
                                 }}
+                                title={title}
                             >
                                 {truncateText(title, 61)}
                             </MangaTitle>
@@ -244,7 +246,7 @@ const MangaCard = React.forwardRef<HTMLDivElement, IProps>((props: IProps, ref) 
                                 width: 'min-content',
                             }}
                         >
-                            <Typography variant="h5" component="h2">
+                            <Typography variant="h5" component="h2" title={title}>
                                 {truncateText(title, 61)}
                             </Typography>
                         </Box>


### PR DESCRIPTION
Shows a tooltip with the full manga title while hovering over the manga title.
In case the title is truncated it's still possible to view the full manga title.
Same way as it is done on e.g. Twitch or YouTube