### PR TITLE
Ignore filters while searching

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -46,9 +46,13 @@ const filterManga = (
     query: NullAndUndefined<string>,
     unread: NullAndUndefined<boolean>,
     downloaded: NullAndUndefined<boolean>,
-): IMangaCard[] => manga.filter((m) => downloadedFilter(downloaded, m)
-        && unreadFilter(unread, m)
-        && queryFilter(query, m));
+): IMangaCard[] => manga.filter((m) => {
+    if (query) {
+        return queryFilter(query, m);
+    }
+
+    return downloadedFilter(downloaded, m) && unreadFilter(unread, m);
+});
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>
     // eslint-disable-next-line implicit-arrow-linebreak


### PR DESCRIPTION
Search was only searching in the filtered manga, thus, it was not possible to find a manga that was not included in the set filters

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->