### PR TITLE
Add Pagination to Libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 .eslintcache
 .vscode
 .env
+.idea
 
 build/*

--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -23,7 +23,7 @@ export interface IMangaGridProps {
     lastPageNum: number;
     setLastPageNum: (lastPageNum: number) => void;
     gridLayout?: GridLayout;
-    horisontal?: boolean | undefined;
+    horizontal?: boolean | undefined;
     noFaces?: boolean | undefined;
     inLibraryIndicator?: boolean;
 }
@@ -38,7 +38,7 @@ const MangaGrid: React.FC<IMangaGridProps> = (props) => {
         lastPageNum,
         setLastPageNum,
         gridLayout,
-        horisontal,
+        horizontal,
         noFaces,
         inLibraryIndicator,
     } = props;
@@ -113,7 +113,7 @@ const MangaGrid: React.FC<IMangaGridProps> = (props) => {
                 container
                 spacing={1}
                 style={
-                    horisontal
+                    horizontal
                         ? {
                               margin: 0,
                               width: '100%',

--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -258,11 +258,7 @@ export default function ReaderNavBar(props: IProps) {
                     <Navigation>
                         <PageNavigation>
                             <span>Currently on page</span>
-                            <FormControl
-                                size="small"
-                                sx={{ margin: '0 5px' }}
-                                disabled={chapter.pageCount === -1}
-                            >
+                            <FormControl size="small" sx={{ margin: '0 5px' }} disabled={chapter.pageCount === -1}>
                                 <Select
                                     MenuProps={MenuProps}
                                     value={chapter.pageCount > -1 ? curPage : ''}
@@ -300,11 +296,7 @@ export default function ReaderNavBar(props: IProps) {
                             >
                                 <KeyboardArrowLeftIcon />
                             </IconButton>
-                            <FormControl
-                                sx={{ gridArea: 'current' }}
-                                size="small"
-                                disabled={chapter.index < 1}
-                            >
+                            <FormControl sx={{ gridArea: 'current' }} size="small" disabled={chapter.index < 1}>
                                 <Select
                                     MenuProps={MenuProps}
                                     value={chapter.index >= 1 ? chapter.index : ''}
@@ -324,19 +316,16 @@ export default function ReaderNavBar(props: IProps) {
                                         .map((ignoreValue, index) => (
                                             // eslint-disable-next-line  max-len
                                             // eslint-disable-next-line  react/no-array-index-key
-                                            <MenuItem
-                                                key={`Chapter#${index + 1}`}
-                                                value={index + 1}
-                                            >{`Chapter ${index + 1}`}</MenuItem>
+                                            <MenuItem key={`Chapter#${index + 1}`} value={index + 1}>{`Chapter ${
+                                                index + 1
+                                            }`}</MenuItem>
                                         ))}
                                 </Select>
                             </FormControl>
                             <IconButton
                                 title="Next Chapter"
                                 sx={{ gridArea: 'next' }}
-                                disabled={
-                                    chapter.index < 1 || chapter.index >= chapter.chapterCount
-                                }
+                                disabled={chapter.index < 1 || chapter.index >= chapter.chapterCount}
                                 onClick={() => {
                                     history.replace({
                                         pathname: `/manga/${manga.id}/chapter/${chapter.index + 1}`,

--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -51,10 +51,6 @@ export default function Library() {
         };
     }, []);
 
-    // a hack so MangaGrid doesn't stop working. I won't change it in case
-    // if I do manga pagination for library..
-    const [lastPageNum, setLastPageNum] = useState<number>(1);
-
     const handleTabChange = (newTab: number) => {
         setTabSearchParam(newTab === 0 ? undefined : newTab);
     };
@@ -76,9 +72,6 @@ export default function Library() {
             <LibraryMangaGrid
                 mangas={mangas}
                 lastLibraryUpdate={lastLibraryUpdate}
-                hasNextPage={false}
-                lastPageNum={lastPageNum}
-                setLastPageNum={setLastPageNum}
                 message="Your Library is empty"
                 isLoading={activeTab != null && mangaLoading}
             />
@@ -117,9 +110,6 @@ export default function Library() {
                             <LibraryMangaGrid
                                 mangas={mangas}
                                 lastLibraryUpdate={lastLibraryUpdate}
-                                hasNextPage={false}
-                                lastPageNum={lastPageNum}
-                                setLastPageNum={setLastPageNum}
                                 message="Category is Empty"
                                 isLoading={mangaLoading}
                             />

--- a/src/screens/SearchAll.tsx
+++ b/src/screens/SearchAll.tsx
@@ -211,7 +211,7 @@ const SearchAll: React.FC = () => {
                                 hasNextPage={false}
                                 lastPageNum={lastPageNum}
                                 setLastPageNum={setLastPageNum}
-                                horisontal
+                                horizontal
                                 noFaces
                                 message={fetched[id] ? 'No manga was found!' : undefined}
                                 inLibraryIndicator


### PR DESCRIPTION
# What
This PR adds pagination feature to WebUI. This means that mangas will load 10 at a time until your page is filled, and when you scroll down, more mangas will be loaded

# Why
Web UI is very slow when dealing with large libraries. Most of this can be attributed to React trying to create all manga cards at the load of page. Adding pagination slows this process down so that this is only done when needed. This makes the page more responsive so that the user can start doing other operations much sooner than before.
The performance improvements are even more visible in mobile devices with limited processing power

# Other Changes
1. The pagination implementation is being moved from `Library` to `LibraryMangaGrid`. This has been done since pagination cannot be done until filteration and sorting is done. Since `LibraryMangaGrid` implements both of these features, it makes sense to move it there.
2. Order of filteration and sorting has been flipped. This does not do anything functionally, but sorting will have to deal with less elements(leading to a very very minute performance imporvement). Tried [this script](https://jsfiddle.net/z9tgdorj/) on local console, saw a 12ms improvement