### PR TITLE
Adds search by genre to WebUI

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -53,6 +53,7 @@ const filterManga = (
     unread: NullAndUndefined<boolean>,
     downloaded: NullAndUndefined<boolean>,
 ): IMangaCard[] => {
+    let filteredManga: IMangaCard[] = [];
     if (query) {
         const titleFilteredManga = manga.filter((m) => queryFilter(query, m));
         const genreFilteredManga = manga.filter((m) => queryGenreFilter(query, m));
@@ -63,15 +64,12 @@ const filterManga = (
             }
             return acc;
         }, {});
-        return Object.values(unique);
+        filteredManga = Object.values(unique);
     }
-    return manga.filter((m) => {
-        if (query) {
-            return queryFilter(query, m);
-        }
-
-        return downloadedFilter(downloaded, m) && unreadFilter(unread, m);
-    });
+    filteredManga = (filteredManga.length ? filteredManga : manga).filter(
+        (m) => downloadedFilter(downloaded, m) && unreadFilter(unread, m),
+    );
+    return filteredManga;
 };
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -41,19 +41,38 @@ const queryFilter = (query: NullAndUndefined<string>, { title }: IMangaCard): bo
     return title.toLowerCase().includes(query.toLowerCase());
 };
 
+const queryGenreFilter = (query: NullAndUndefined<string>, { genre }: IMangaCard): boolean => {
+    if (!query) return true;
+    const queries = query.split(',').map((str) => str.toLowerCase().trim());
+    return queries.every((element) => genre.map((el) => el.toLowerCase()).includes(element));
+};
+
 const filterManga = (
     manga: IMangaCard[],
     query: NullAndUndefined<string>,
     unread: NullAndUndefined<boolean>,
     downloaded: NullAndUndefined<boolean>,
-): IMangaCard[] =>
-    manga.filter((m) => {
+): IMangaCard[] => {
+    if (query) {
+        const titleFilteredManga = manga.filter((m) => queryFilter(query, m));
+        const genreFilteredManga = manga.filter((m) => queryGenreFilter(query, m));
+        const unique = titleFilteredManga.concat(genreFilteredManga).reduce((acc: Record<number, IMangaCard>, obj) => {
+            const { id } = obj;
+            if (!acc[id]) {
+                acc[id] = obj;
+            }
+            return acc;
+        }, {});
+        return Object.values(unique);
+    }
+    return manga.filter((m) => {
         if (query) {
             return queryFilter(query, m);
         }
 
         return downloadedFilter(downloaded, m) && unreadFilter(unread, m);
     });
+};
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>
     // eslint-disable-next-line implicit-arrow-linebreak

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -70,6 +70,7 @@ export default function Reader() {
         id: +mangaId,
         title: '',
         thumbnailUrl: '',
+        genre: [],
     });
     const [chapter, setChapter] = useState<IChapter | IPartialChapter>(initialChapter());
     const [curPage, setCurPage] = useState<number>(0);

--- a/src/screens/SourceMangas.tsx
+++ b/src/screens/SourceMangas.tsx
@@ -202,6 +202,7 @@ export default function SourceMangas(props: { popular: boolean }) {
                             thumbnailUrl: it.thumbnailUrl,
                             id: it.id,
                             inLibrary: it.inLibrary,
+                            genre: it.genre,
                         })),
                     ]);
                     setHasNextPage(data.hasNextPage);

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -78,6 +78,7 @@ type MetadataKeyValuePair = [AppMetadataKeys, AllowedMetadataValueTypes];
 interface IMangaCard {
     id: number;
     title: string;
+    genre: string[];
     thumbnailUrl: string;
     unreadCount?: number;
     downloadCount?: number;


### PR DESCRIPTION
# What
As the title says, this feature will allow you to use the search input with genre as well. You can input comma separated genre to search by them
**Note: You need to put the full genre text (case does not matter)**
# Why
Searching by genre is very cool, it has the ability to give you exactly what you are in the mood for. Want something that has a lot of action in it, but also monsters. Type in `action, monster` and it will give you all the mangas in your library that are tagged with them
**Disclaimer: Search by genre is subject to information provided by extension and sources. So if your source/extension does not provide proper genre details, this will not work**