### PR TITLE
Introduced override filters while searching setting

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -54,12 +54,12 @@ const filterManga = (
     query: NullAndUndefined<string>,
     unread: NullAndUndefined<boolean>,
     downloaded: NullAndUndefined<boolean>,
-    overrideFilters: boolean,
+    ignoreFilters: boolean,
 ): IMangaCard[] =>
     mangas.filter(
         (manga) =>
             (queryFilter(query, manga) || queryGenreFilter(query, manga)) &&
-            (overrideFilters || (downloadedFilter(downloaded, manga) && unreadFilter(unread, manga))),
+            (ignoreFilters || (downloadedFilter(downloaded, manga) && unreadFilter(unread, manga))),
     );
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>
@@ -124,10 +124,10 @@ const LibraryMangaGrid: React.FC<LibraryMangaGridProps & { lastLibraryUpdate: nu
     const { settings } = useSearchSettings();
 
     useEffect(() => {
-        setFilteredManga(filterManga(mangas, query, unread, downloaded, settings.overrideFilters));
+        setFilteredManga(filterManga(mangas, query, unread, downloaded, settings.ignoreFilters));
         setLastPageNum(defaultPageNumber);
         window.scrollTo(0, 0);
-    }, [mangas, query, unread, downloaded, settings.overrideFilters]);
+    }, [mangas, query, unread, downloaded, settings.ignoreFilters]);
 
     useEffect(() => {
         setSortedManga(sortManga(filteredManga, options.sorts, options.sortDesc));

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -35,6 +35,7 @@ import NavbarContext from 'components/context/NavbarContext';
 import DarkTheme from 'components/context/DarkTheme';
 import useLocalStorage from 'util/useLocalStorage';
 import ListItemLink from 'components/util/ListItemLink';
+import SearchSettings from 'screens/settings/SearchSettings';
 
 export default function Settings() {
     const { setTitle, setAction } = useContext(NavbarContext);
@@ -121,6 +122,7 @@ export default function Settings() {
                         <Switch edge="end" checked={darkTheme} onChange={() => setDarkTheme(!darkTheme)} />
                     </ListItemSecondaryAction>
                 </ListItem>
+                <SearchSettings />
                 <ListItemButton>
                     <ListItemIcon>
                         <ViewModuleIcon />

--- a/src/screens/settings/SearchSettings.tsx
+++ b/src/screens/settings/SearchSettings.tsx
@@ -1,12 +1,12 @@
 import { ListItem, ListItemText, Switch } from '@mui/material';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import React from 'react';
-import { ISearchSettings } from '../../typings';
 import { useSearchSettings } from 'util/searchSettings';
 import { requestUpdateServerMetadata } from 'util/metadata';
 import makeToast from 'components/util/Toast';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import SearchIcon from '@mui/icons-material/Search';
+import { ISearchSettings } from 'typings';
 
 export default function SearchSettings() {
     const { metadata, settings } = useSearchSettings();

--- a/src/screens/settings/SearchSettings.tsx
+++ b/src/screens/settings/SearchSettings.tsx
@@ -1,0 +1,33 @@
+import { ListItem, ListItemText, Switch } from '@mui/material';
+import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
+import React from 'react';
+import { useSearchSettings } from 'util/searchSettings';
+import { requestUpdateServerMetadata } from 'util/metadata';
+import makeToast from 'components/util/Toast';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import SearchIcon from '@mui/icons-material/Search';
+
+export default function SearchSettings() {
+    const { metadata, settings } = useSearchSettings();
+
+    const setSettingValue = (key: keyof ISearchSettings, value: boolean) => {
+        requestUpdateServerMetadata(metadata ?? {}, [[key, value]]).catch(() =>
+            makeToast('Failed to save the default reader settings to the server', 'warning'),
+        );
+    };
+    return (
+        <ListItem>
+            <ListItemIcon>
+                <SearchIcon />
+            </ListItemIcon>
+            <ListItemText primary="Override Filters when Searching" />
+            <ListItemSecondaryAction>
+                <Switch
+                    edge="end"
+                    checked={settings.overrideFilters}
+                    onChange={(e) => setSettingValue('overrideFilters', e.target.checked)}
+                />
+            </ListItemSecondaryAction>
+        </ListItem>
+    );
+}

--- a/src/screens/settings/SearchSettings.tsx
+++ b/src/screens/settings/SearchSettings.tsx
@@ -6,12 +6,12 @@ import { requestUpdateServerMetadata } from 'util/metadata';
 import makeToast from 'components/util/Toast';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import SearchIcon from '@mui/icons-material/Search';
-import { ISearchSettings } from 'typings';
+import { SearchMetadataKeys } from 'typings';
 
 export default function SearchSettings() {
     const { metadata, settings } = useSearchSettings();
 
-    const setSettingValue = (key: keyof ISearchSettings, value: boolean) => {
+    const setSettingValue = (key: SearchMetadataKeys, value: boolean) => {
         requestUpdateServerMetadata(metadata ?? {}, [[key, value]]).catch(() =>
             makeToast('Failed to save the default search settings to the server', 'warning'),
         );

--- a/src/screens/settings/SearchSettings.tsx
+++ b/src/screens/settings/SearchSettings.tsx
@@ -25,8 +25,8 @@ export default function SearchSettings() {
             <ListItemSecondaryAction>
                 <Switch
                     edge="end"
-                    checked={settings.overrideFilters}
-                    onChange={(e) => setSettingValue('overrideFilters', e.target.checked)}
+                    checked={settings.ignoreFilters}
+                    onChange={(e) => setSettingValue('ignoreFilters', e.target.checked)}
                 />
             </ListItemSecondaryAction>
         </ListItem>

--- a/src/screens/settings/SearchSettings.tsx
+++ b/src/screens/settings/SearchSettings.tsx
@@ -1,6 +1,7 @@
 import { ListItem, ListItemText, Switch } from '@mui/material';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import React from 'react';
+import { ISearchSettings } from '../../typings';
 import { useSearchSettings } from 'util/searchSettings';
 import { requestUpdateServerMetadata } from 'util/metadata';
 import makeToast from 'components/util/Toast';
@@ -12,7 +13,7 @@ export default function SearchSettings() {
 
     const setSettingValue = (key: keyof ISearchSettings, value: boolean) => {
         requestUpdateServerMetadata(metadata ?? {}, [[key, value]]).catch(() =>
-            makeToast('Failed to save the default reader settings to the server', 'warning'),
+            makeToast('Failed to save the default search settings to the server', 'warning'),
         );
     };
     return (
@@ -20,7 +21,7 @@ export default function SearchSettings() {
             <ListItemIcon>
                 <SearchIcon />
             </ListItemIcon>
-            <ListItemText primary="Override Filters when Searching" />
+            <ListItemText primary="Ignore Filters when Searching" />
             <ListItemSecondaryAction>
                 <Switch
                     edge="end"

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -69,7 +69,7 @@ interface IMetadataHolder<VALUES extends AllowedMetadataValueTypes = string> {
 
 type AllowedMetadataValueTypes = string | boolean | number | undefined;
 
-type MangaMetadataKeys = keyof IReaderSettings;
+type MangaMetadataKeys = keyof (IReaderSettings & ISearchSettings);
 
 type AppMetadataKeys = MangaMetadataKeys;
 
@@ -175,6 +175,10 @@ interface IReaderSettings {
     showPageNumber: boolean;
     loadNextOnEnding: boolean;
     readerType: ReaderType;
+}
+
+interface ISearchSettings {
+    overrideFilters: boolean;
 }
 
 interface IReaderPage {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -81,9 +81,9 @@ export interface IMetadataHolder<VALUES extends AllowedMetadataValueTypes = stri
 
 export type AllowedMetadataValueTypes = string | boolean | number | undefined;
 
-export type MangaMetadataKeys = keyof (IReaderSettings & ISearchSettings);
+export type MangaMetadataKeys = IReaderSettings;
 
-export type AppMetadataKeys = MangaMetadataKeys;
+export type AppMetadataKeys = MangaMetadataKeys & ISearchSettings;
 
 export type MetadataKeyValuePair = [AppMetadataKeys, AllowedMetadataValueTypes];
 
@@ -191,7 +191,7 @@ export interface IReaderSettings {
 }
 
 export interface ISearchSettings {
-    overrideFilters: boolean;
+    ignoreFilters: boolean;
 }
 
 export interface IReaderPage {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -81,9 +81,11 @@ export interface IMetadataHolder<VALUES extends AllowedMetadataValueTypes = stri
 
 export type AllowedMetadataValueTypes = string | boolean | number | undefined;
 
-export type MangaMetadataKeys = IReaderSettings;
+export type MangaMetadataKeys = keyof IReaderSettings;
 
-export type AppMetadataKeys = MangaMetadataKeys & ISearchSettings;
+export type SearchMetadataKeys = keyof ISearchSettings;
+
+export type AppMetadataKeys = MangaMetadataKeys | SearchMetadataKeys;
 
 export type MetadataKeyValuePair = [AppMetadataKeys, AllowedMetadataValueTypes];
 

--- a/src/util/searchSettings.ts
+++ b/src/util/searchSettings.ts
@@ -1,12 +1,13 @@
 import { useQuery } from 'util/client';
 import { getMetadataFrom } from 'util/metadata';
+import { IMetadata, ISearchSettings, MetadataKeyValuePair } from 'typings';
 
 export const getDefaultSettings = () =>
     ({
         overrideFilters: false,
     } as ISearchSettings);
 
-const getReaderSettingsWithDefaultValueFallback = (
+const getSearchSettingsWithDefaultValueFallback = (
     meta?: IMetadata,
     defaultSettings?: ISearchSettings,
     applyMetadataMigration: boolean = true,
@@ -24,7 +25,7 @@ export const useSearchSettings = (): {
     loading: boolean;
 } => {
     const { data: meta, loading } = useQuery<IMetadata>('/api/v1/meta');
-    const settings = getReaderSettingsWithDefaultValueFallback(meta);
+    const settings = getSearchSettingsWithDefaultValueFallback(meta);
 
     return { metadata: meta, settings, loading };
 };

--- a/src/util/searchSettings.ts
+++ b/src/util/searchSettings.ts
@@ -4,7 +4,7 @@ import { IMetadata, ISearchSettings, MetadataKeyValuePair } from 'typings';
 
 export const getDefaultSettings = () =>
     ({
-        overrideFilters: false,
+        ignoreFilters: false,
     } as ISearchSettings);
 
 const getSearchSettingsWithDefaultValueFallback = (

--- a/src/util/searchSettings.ts
+++ b/src/util/searchSettings.ts
@@ -1,0 +1,30 @@
+import { useQuery } from 'util/client';
+import { getMetadataFrom } from 'util/metadata';
+
+export const getDefaultSettings = () =>
+    ({
+        overrideFilters: false,
+    } as ISearchSettings);
+
+const getReaderSettingsWithDefaultValueFallback = (
+    meta?: IMetadata,
+    defaultSettings?: ISearchSettings,
+    applyMetadataMigration: boolean = true,
+): ISearchSettings => ({
+    ...(getMetadataFrom(
+        { meta },
+        Object.entries(defaultSettings ?? getDefaultSettings()) as MetadataKeyValuePair[],
+        applyMetadataMigration,
+    ) as unknown as ISearchSettings),
+});
+
+export const useSearchSettings = (): {
+    metadata?: IMetadata;
+    settings: ISearchSettings;
+    loading: boolean;
+} => {
+    const { data: meta, loading } = useQuery<IMetadata>('/api/v1/meta');
+    const settings = getReaderSettingsWithDefaultValueFallback(meta);
+
+    return { metadata: meta, settings, loading };
+};


### PR DESCRIPTION
# What
This PR introduces a new setting called `Ignre Filters while Searching`. This setting as it says determines whether manga search will respect the filters that are set such as Downloaded, Unread, etc.

# Why
This will resolve a previous issue that some users had with the search behaviour which resulted in #226. This PR completely ignores the filters while searching. This PR is middle ground to keep most users satisfied with the Web UI behaviour