### PR TITLE
[#245] Get first unread chapter from original chapter list

### DIFF
--- a/src/components/manga/ChapterList.tsx
+++ b/src/components/manga/ChapterList.tsx
@@ -110,11 +110,11 @@ const ChapterList: React.FC<IProps> = ({ mangaId }) => {
 
     const firstUnreadChapter = useMemo(
         () =>
-            visibleChapters
+            chapters
                 .slice()
                 .reverse()
-                .find((c) => c.read === false),
-        [visibleChapters],
+                .find((chapter) => !chapter.read),
+        [chapters],
     );
 
     const handleSelection = (index: number) => {


### PR DESCRIPTION
fixes #245 

The first unread chapter was retrieved from the filtered and sorted chapter list, which could result in e.g. incorrectly recognizing the latest released chapter as the first unread chapter.

Ideally the server would return the manga with its last read chapter, but this is currently not available.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->