### PR TITLE
Show empty library in case search doesn't match anything

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -53,25 +53,13 @@ const filterManga = (
     query: NullAndUndefined<string>,
     unread: NullAndUndefined<boolean>,
     downloaded: NullAndUndefined<boolean>,
-): IMangaCard[] => {
-    let filteredManga: IMangaCard[] = [];
-    if (query) {
-        const titleFilteredManga = manga.filter((m) => queryFilter(query, m));
-        const genreFilteredManga = manga.filter((m) => queryGenreFilter(query, m));
-        const unique = titleFilteredManga.concat(genreFilteredManga).reduce((acc: Record<number, IMangaCard>, obj) => {
-            const { id } = obj;
-            if (!acc[id]) {
-                acc[id] = obj;
-            }
-            return acc;
-        }, {});
-        filteredManga = Object.values(unique);
-    }
-    filteredManga = (filteredManga.length ? filteredManga : manga).filter(
-        (m) => downloadedFilter(downloaded, m) && unreadFilter(unread, m),
+): IMangaCard[] =>
+    manga.filter(
+        (m) =>
+            (queryFilter(query, m) || queryGenreFilter(query, m)) &&
+            downloadedFilter(downloaded, m) &&
+            unreadFilter(unread, m),
     );
-    return filteredManga;
-};
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>
     // eslint-disable-next-line implicit-arrow-linebreak

--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -49,16 +49,16 @@ const queryGenreFilter = (query: NullAndUndefined<string>, { genre }: IMangaCard
 };
 
 const filterManga = (
-    manga: IMangaCard[],
+    mangas: IMangaCard[],
     query: NullAndUndefined<string>,
     unread: NullAndUndefined<boolean>,
     downloaded: NullAndUndefined<boolean>,
 ): IMangaCard[] =>
-    manga.filter(
-        (m) =>
-            (queryFilter(query, m) || queryGenreFilter(query, m)) &&
-            downloadedFilter(downloaded, m) &&
-            unreadFilter(unread, m),
+    mangas.filter(
+        (manga) =>
+            (queryFilter(query, manga) || queryGenreFilter(query, manga)) &&
+            downloadedFilter(downloaded, manga) &&
+            unreadFilter(unread, manga),
     );
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>


### PR DESCRIPTION
In case the search didn't match anything all mangas where shown instead of an empty library.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->