### PR TITLE
Added sort by last read

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -70,6 +70,8 @@ const sortByTitle = (a: IMangaCard, b: IMangaCard): number => a.title.localeComp
 
 const sortByDateAdded = (a: IMangaCard, b: IMangaCard): number => a.inLibraryAt - b.inLibraryAt;
 
+const sortByLastRead = (a: IMangaCard, b: IMangaCard): number => b.lastReadAt - a.lastReadAt;
+
 const sortManga = (
     manga: IMangaCard[],
     sort: NullAndUndefined<LibrarySortMode>,
@@ -86,6 +88,9 @@ const sortManga = (
             break;
         case 'sortToRead':
             result.sort(sortByUnread);
+            break;
+        case 'sortLastRead':
+            result.sort(sortByLastRead);
             break;
         default:
             break;

--- a/src/components/library/LibraryOptionsPanel.tsx
+++ b/src/components/library/LibraryOptionsPanel.tsx
@@ -25,6 +25,7 @@ const SORT_OPTIONS: [LibrarySortMode, string][] = [
     ['sortToRead', 'By Unread chapters'],
     ['sortAlph', 'Alphabetically'],
     ['sortDateAdded', 'Date Added'],
+    ['sortLastRead', 'Last Read'],
 ];
 
 interface IProps {

--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -73,6 +73,7 @@ export default function Reader() {
         thumbnailUrl: '',
         genre: [],
         inLibraryAt: 0,
+        lastReadAt: 0,
     });
     const [chapter, setChapter] = useState<IChapter | IPartialChapter>(initialChapter());
     const [curPage, setCurPage] = useState<number>(0);

--- a/src/screens/SourceMangas.tsx
+++ b/src/screens/SourceMangas.tsx
@@ -205,6 +205,7 @@ export default function SourceMangas(props: { popular: boolean }) {
                             inLibrary: it.inLibrary,
                             genre: it.genre,
                             inLibraryAt: it.inLibraryAt,
+                            lastReadAt: it.lastReadAt,
                         })),
                     ]);
                     setHasNextPage(data.hasNextPage);

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -99,6 +99,7 @@ export interface IMangaCard {
     inLibrary?: boolean;
     meta?: IMetadata;
     inLibraryAt: number;
+    lastReadAt: number;
 }
 
 export interface IManga {
@@ -331,7 +332,7 @@ export type ChapterOptionsReducerAction =
     | { type: 'sortReverse' }
     | { type: 'showChapterNumber' };
 
-export type LibrarySortMode = 'sortToRead' | 'sortAlph' | 'sortDateAdded';
+export type LibrarySortMode = 'sortToRead' | 'sortAlph' | 'sortDateAdded' | 'sortLastRead';
 
 enum GridLayout {
     Compact = 0,


### PR DESCRIPTION
## New sort method
This PR adds a new way to sort your manga library. Sorting by Last read, can be very useful to quickly get to the manga that you were reading last, or discover something that you haven't touched yet