### PR TITLE
Ignore filters only while searching

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -56,11 +56,14 @@ const filterManga = (
     downloaded: NullAndUndefined<boolean>,
     ignoreFilters: boolean,
 ): IMangaCard[] =>
-    mangas.filter(
-        (manga) =>
-            (queryFilter(query, manga) || queryGenreFilter(query, manga)) &&
-            (ignoreFilters || (downloadedFilter(downloaded, manga) && unreadFilter(unread, manga))),
-    );
+    mangas.filter((manga) => {
+        const ignoreFiltersWhileSearching = ignoreFilters && query?.length;
+        const matchesSearch = queryFilter(query, manga) || queryGenreFilter(query, manga);
+        const matchesFilters =
+            ignoreFiltersWhileSearching || (downloadedFilter(downloaded, manga) && unreadFilter(unread, manga));
+
+        return matchesSearch && matchesFilters;
+    });
 
 const sortByUnread = (a: IMangaCard, b: IMangaCard): number =>
     // eslint-disable-next-line implicit-arrow-linebreak


### PR DESCRIPTION
In case the "ignoreFilters" flag was set to true and the search string was empty/undefined all mangas of the category were visible, ignoring the set filters.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->