### PR TITLE
Disable "SSR" option in "useMediaQuery"

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -126,7 +126,7 @@ const LibraryMangaGrid: React.FC<LibraryMangaGridProps & { lastLibraryUpdate: nu
     const [filteredManga, setFilteredManga] = useState<IMangaCard[]>([]);
     const totalPages = (mangas ?? []).length / 10;
     const theme = useTheme();
-    const isLargeScreen = useMediaQuery(theme.breakpoints.up('sm'));
+    const isLargeScreen = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
     const defaultPageNumber = isLargeScreen ? 4 : 1;
     const [lastPageNum, setLastPageNum] = useState<number>(defaultPageNumber);
     const { settings } = useSearchSettings();


### PR DESCRIPTION
"useMediaQuery" renders once with default values and only on the second render with the resolved values. (https://mui.com/material-ui/react-use-media-query/#client-side-only-rendering)

Thus, "lastPageNum" can potentially get initialized with the value for small/medium screens instead for large screens.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->