### PR TITLE
Keep "add category" fab position fixed

### DIFF
--- a/src/screens/settings/Categories.tsx
+++ b/src/screens/settings/Categories.tsx
@@ -189,7 +189,7 @@ export default function Categories() {
                 color="primary"
                 aria-label="add"
                 style={{
-                    position: 'absolute',
+                    position: 'fixed',
                     bottom: theme.spacing(2),
                     right: theme.spacing(2),
                 }}


### PR DESCRIPTION
fixes #244

The button is supposed to stay in the bottom right corner at all times

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->