### PR TITLE
Prevent chapter FAB from changing position when selecting chapters

### DIFF
--- a/src/components/util/StyledFab.tsx
+++ b/src/components/util/StyledFab.tsx
@@ -4,8 +4,8 @@ import { styled } from '@mui/system';
 export const DEFAULT_FAB_STYLE = {
     position: 'fixed',
     height: '48px',
-    right: '3em',
-    bottom: '2em',
+    right: '48px',
+    bottom: '28px',
 } as const;
 
 export const DEFAULT_FULL_FAB_HEIGHT = `calc(${DEFAULT_FAB_STYLE.bottom} + ${DEFAULT_FAB_STYLE.height})`;


### PR DESCRIPTION
When selecting chapters the FAB button slightly moved further up and to the right. This happened because "em" was used for the positioning and the "SelectionFAB" being inside a "Box" component while the "Start/ResumeFAB" had "no" parent component.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->