### PR TITLE
Trigger global search request

### DIFF
--- a/src/screens/SearchAll.tsx
+++ b/src/screens/SearchAll.tsx
@@ -46,7 +46,7 @@ const SearchAll: React.FC = () => {
     const [shownLangs, setShownLangs] = useLocalStorage<string[]>('shownSourceLangs', sourceDefualtLangs());
     const [showNsfw] = useLocalStorage<boolean>('showNsfw', true);
 
-    const { data: unsortedSources = [], isLoading: FetchedSources } = requestManager.useGetSourceList();
+    const { data: unsortedSources = [], isLoading: isLoadingSources } = requestManager.useGetSourceList();
     const sources = useMemo(
         () =>
             unsortedSources.sort((a: { displayName: string }, b: { displayName: string }) => {
@@ -116,7 +116,7 @@ const SearchAll: React.FC = () => {
     }, [ResetUI]);
 
     useEffect(() => {
-        if (query && FetchedSources) {
+        if (query && !isLoadingSources) {
             const delayDebounceFn = setTimeout(() => {
                 setTriggerUpdate(0);
             }, 1000);


### PR DESCRIPTION
Issue introduced with a457d80c446960df5644513fdf4d3a11974243c7. "FetchedSources" was changed to represent the loading state of the request, but it was forgotten to update its usage

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->