### PR TITLE
Add fit page to window reader setting

### DIFF
--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -261,6 +261,7 @@ export default function ReaderNavBar(props: IProps) {
                             showPageNumber={settings.showPageNumber}
                             loadNextOnEnding={settings.loadNextOnEnding}
                             skipDupChapters={settings.skipDupChapters}
+                            fitToWindow={settings.fitToWindow}
                             readerType={settings.readerType}
                         />
                     </Collapse>

--- a/src/components/navbar/ReaderNavBar.tsx
+++ b/src/components/navbar/ReaderNavBar.tsx
@@ -261,7 +261,7 @@ export default function ReaderNavBar(props: IProps) {
                             showPageNumber={settings.showPageNumber}
                             loadNextOnEnding={settings.loadNextOnEnding}
                             skipDupChapters={settings.skipDupChapters}
-                            fitToWindow={settings.fitToWindow}
+                            fitPageToWindow={settings.fitPageToWindow}
                             readerType={settings.readerType}
                         />
                     </Collapse>

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -30,7 +30,7 @@ function imageStyle(settings: IReaderSettings): any {
         };
     }, []);
     if (
-        settings.fitToWindow ||
+        settings.fitPageToWindow ||
         settings.readerType === 'DoubleLTR' ||
         settings.readerType === 'DoubleRTL' ||
         settings.readerType === 'ContinuesHorizontalLTR' ||

--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -30,6 +30,7 @@ function imageStyle(settings: IReaderSettings): any {
         };
     }, []);
     if (
+        settings.fitToWindow ||
         settings.readerType === 'DoubleLTR' ||
         settings.readerType === 'DoubleRTL' ||
         settings.readerType === 'ContinuesHorizontalLTR' ||

--- a/src/components/reader/ReaderSettingsOptions.tsx
+++ b/src/components/reader/ReaderSettingsOptions.tsx
@@ -79,7 +79,7 @@ export default function ReaderSettingsOptions({
             </ListItem>
             {fitPageToWindowEligible ? (
                 <ListItem>
-                    <ListItemText primary={t('reader.settings.label.fit_to_window')} />
+                    <ListItemText primary={t('reader.settings.label.fit_page_to_window')} />
                     <ListItemSecondaryAction>
                         <Switch
                             edge="end"

--- a/src/components/reader/ReaderSettingsOptions.tsx
+++ b/src/components/reader/ReaderSettingsOptions.tsx
@@ -25,10 +25,16 @@ export default function ReaderSettingsOptions({
     showPageNumber,
     skipDupChapters,
     setSettingValue,
-    fitToWindow,
+    fitPageToWindow,
 }: IProps) {
     const { t } = useTranslation();
-
+    const fitPageToWindowEligible = [
+        'ContinuesVertical',
+        'Webtoon',
+        'SingleVertical',
+        'SingleRTL',
+        'SingleLTR',
+    ].includes(readerType);
     return (
         <List>
             <ListItem>
@@ -71,16 +77,18 @@ export default function ReaderSettingsOptions({
                     />
                 </ListItemSecondaryAction>
             </ListItem>
-            <ListItem>
-                <ListItemText primary={t('reader.settings.label.fit_to_window')} />
-                <ListItemSecondaryAction>
-                    <Switch
-                        edge="end"
-                        checked={fitToWindow}
-                        onChange={(e) => setSettingValue('fitToWindow', e.target.checked)}
-                    />
-                </ListItemSecondaryAction>
-            </ListItem>
+            {fitPageToWindowEligible ? (
+                <ListItem>
+                    <ListItemText primary={t('reader.settings.label.fit_to_window')} />
+                    <ListItemSecondaryAction>
+                        <Switch
+                            edge="end"
+                            checked={fitPageToWindow}
+                            onChange={(e) => setSettingValue('fitPageToWindow', e.target.checked)}
+                        />
+                    </ListItemSecondaryAction>
+                </ListItem>
+            ) : null}
             <ListItem>
                 <ListItemText primary={t('reader.settings.label.reader_type')} />
                 <Select

--- a/src/components/reader/ReaderSettingsOptions.tsx
+++ b/src/components/reader/ReaderSettingsOptions.tsx
@@ -25,6 +25,7 @@ export default function ReaderSettingsOptions({
     showPageNumber,
     skipDupChapters,
     setSettingValue,
+    fitToWindow,
 }: IProps) {
     const { t } = useTranslation();
 
@@ -67,6 +68,16 @@ export default function ReaderSettingsOptions({
                         edge="end"
                         checked={skipDupChapters}
                         onChange={(e) => setSettingValue('skipDupChapters', e.target.checked)}
+                    />
+                </ListItemSecondaryAction>
+            </ListItem>
+            <ListItem>
+                <ListItemText primary={t('reader.settings.label.fit_to_window')} />
+                <ListItemSecondaryAction>
+                    <Switch
+                        edge="end"
+                        checked={fitToWindow}
+                        onChange={(e) => setSettingValue('fitToWindow', e.target.checked)}
                     />
                 </ListItemSecondaryAction>
             </ListItem>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -361,7 +361,8 @@
         "reader_type": "Reader type",
         "show_page_number": "Show page number",
         "skip_dup_chapters": "Skip duplicate chapters",
-        "static_navigation": "Static navigation"
+        "static_navigation": "Static navigation",
+        "fit_to_window": "Fit page to window"
       },
       "reader_type": {
         "label": {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -362,7 +362,7 @@
         "show_page_number": "Show page number",
         "skip_dup_chapters": "Skip duplicate chapters",
         "static_navigation": "Static navigation",
-        "fit_to_window": "Fit page to window"
+        "fit_page_to_window": "Fit page to window"
       },
       "reader_type": {
         "label": {

--- a/src/i18n/locale/es.json
+++ b/src/i18n/locale/es.json
@@ -299,7 +299,8 @@
                 "static_navigation": "Navigación Estática",
                 "show_page_number": "Mostrar numero de pagina",
                 "reader_type": "Tipo de Lector",
-                "skip_dup_chapters": "Omitir capítulos duplicados"
+                "skip_dup_chapters": "Omitir capítulos duplicados",
+                "fit_to_window": "Ajustar página a la ventana"
             },
             "title": {
                 "default_reader_settings": "Ajustes Defecto del Lector",

--- a/src/i18n/locale/es.json
+++ b/src/i18n/locale/es.json
@@ -300,7 +300,7 @@
                 "show_page_number": "Mostrar numero de pagina",
                 "reader_type": "Tipo de Lector",
                 "skip_dup_chapters": "Omitir capítulos duplicados",
-                "fit_to_window": "Ajustar página a la ventana"
+                "fit_page_to_window": "Ajustar página a la ventana"
             },
             "title": {
                 "default_reader_settings": "Ajustes Defecto del Lector",

--- a/src/screens/settings/DefaultReaderSettings.tsx
+++ b/src/screens/settings/DefaultReaderSettings.tsx
@@ -61,7 +61,7 @@ export default function DefaultReaderSettings() {
             showPageNumber={settings.showPageNumber}
             loadNextOnEnding={settings.loadNextOnEnding}
             skipDupChapters={settings.skipDupChapters}
-            fitToWindow={settings.fitToWindow}
+            fitPageToWindow={settings.fitPageToWindow}
             readerType={settings.readerType}
         />
     );

--- a/src/screens/settings/DefaultReaderSettings.tsx
+++ b/src/screens/settings/DefaultReaderSettings.tsx
@@ -61,6 +61,7 @@ export default function DefaultReaderSettings() {
             showPageNumber={settings.showPageNumber}
             loadNextOnEnding={settings.loadNextOnEnding}
             skipDupChapters={settings.skipDupChapters}
+            fitToWindow={settings.fitToWindow}
             readerType={settings.readerType}
         />
     );

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -212,6 +212,7 @@ export interface IReaderSettings {
     showPageNumber: boolean;
     loadNextOnEnding: boolean;
     skipDupChapters: boolean;
+    fitToWindow: boolean;
     readerType: ReaderType;
 }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -212,7 +212,7 @@ export interface IReaderSettings {
     showPageNumber: boolean;
     loadNextOnEnding: boolean;
     skipDupChapters: boolean;
-    fitToWindow: boolean;
+    fitPageToWindow: boolean;
     readerType: ReaderType;
 }
 

--- a/src/util/readerSettings.ts
+++ b/src/util/readerSettings.ts
@@ -19,6 +19,7 @@ export const getDefaultSettings = (): IReaderSettings => ({
     showPageNumber: true,
     loadNextOnEnding: false,
     skipDupChapters: true,
+    fitToWindow: false,
     readerType: 'ContinuesVertical',
 });
 
@@ -71,6 +72,7 @@ export const checkAndHandleMissingStoredReaderSettings = async (
             showPageNumber: undefined,
             loadNextOnEnding: undefined,
             skipDupChapters: undefined,
+            fitToWindow: undefined,
             readerType: undefined,
         },
         false,

--- a/src/util/readerSettings.ts
+++ b/src/util/readerSettings.ts
@@ -19,7 +19,7 @@ export const getDefaultSettings = (): IReaderSettings => ({
     showPageNumber: true,
     loadNextOnEnding: false,
     skipDupChapters: true,
-    fitToWindow: false,
+    fitPageToWindow: false,
     readerType: 'ContinuesVertical',
 });
 
@@ -72,7 +72,7 @@ export const checkAndHandleMissingStoredReaderSettings = async (
             showPageNumber: undefined,
             loadNextOnEnding: undefined,
             skipDupChapters: undefined,
-            fitToWindow: undefined,
+            fitPageToWindow: undefined,
             readerType: undefined,
         },
         false,


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->
## Description
The following change adds a new option to the reader settings called fit page to window. This feature allows users to display pages maximally fitted to the reader window without overflowing vertical or horizontaly.
The behavior is similar to the current page fitting of the two-page or horizontal scroll reader modes. The reader style where the change makes more sense is in both single page modes but it is also useful in webtoon and continues vertical modes.
## Before the change (identical to having the setting disabled)
### Single page
![image](https://github.com/Suwayomi/Tachidesk-WebUI/assets/35273317/b05837f6-a7b1-45a6-b187-3e35738227b1)
### Vertical
![image](https://github.com/Suwayomi/Tachidesk-WebUI/assets/35273317/16324fea-ff47-4cfe-8c00-08087e831646)


## After the change: Disabled
### Single page
![image](https://github.com/Suwayomi/Tachidesk-WebUI/assets/35273317/7b63c731-0bfe-4932-88dc-84ebe927c09e)
### Vertical
![image](https://github.com/Suwayomi/Tachidesk-WebUI/assets/35273317/d5962062-5afb-49d5-986e-3e9274e4c2d0)
## After the change: Enabled
### Single page
![image](https://github.com/Suwayomi/Tachidesk-WebUI/assets/35273317/4ee909d8-953c-416d-ade5-263671f48fe0)
### Vertical
![image](https://github.com/Suwayomi/Tachidesk-WebUI/assets/35273317/df468f18-58d0-49f1-b027-2dd135db797d)
