### PR TITLE
Preserve "SourceMangas" location state

### DIFF
--- a/src/screens/Manga.tsx
+++ b/src/screens/Manga.tsx
@@ -12,7 +12,7 @@ import React, { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import requestManager from '@/lib/RequestManager';
-import NavbarContext, { useSetDefaultBackTo } from '@/components/context/NavbarContext';
+import NavbarContext from '@/components/context/NavbarContext';
 import ChapterList from '@/components/manga/ChapterList';
 import { useRefreshManga } from '@/components/manga/hooks';
 import MangaDetails from '@/components/manga/MangaDetails';
@@ -32,10 +32,6 @@ const Manga: React.FC = () => {
     const { data: manga, error, isLoading, isValidating, mutate } = requestManager.useGetManga(id);
 
     const [refresh, { loading: refreshing }] = useRefreshManga(id);
-
-    useSetDefaultBackTo(
-        manga?.inLibrary === false && manga.sourceId != null ? `/sources/${manga.sourceId}` : '/library',
-    );
 
     useEffect(() => {
         // Automatically fetch manga from source if data is older then 24 hours


### PR DESCRIPTION
Due to setting the "defaultBackTo" url the back button was a Link instead of a normal Button. The Link causes the page to get opened like it's the first time and to get put on top of the browsers history stack. Instead of actually going back in the history. Thus, the previous location state of the "SourceMangas" page was lost and the content type (browse, latest, filter) couldn't be reopened.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->