### PR TITLE
Open reader via the correct url when using resume FAB

### DIFF
--- a/src/components/manga/ResumeFAB.tsx
+++ b/src/components/manga/ResumeFAB.tsx
@@ -23,7 +23,7 @@ export default function ResumeFab(props: ResumeFABProps) {
     const { t } = useTranslation();
 
     const {
-        chapter: { index, lastPageRead },
+        chapter: { index },
         mangaId,
     } = props;
     return (
@@ -31,7 +31,7 @@ export default function ResumeFab(props: ResumeFABProps) {
             component={Link}
             variant="extended"
             color="primary"
-            to={`/manga/${mangaId}/chapter/${index}/page/${lastPageRead}`}
+            to={`/manga/${mangaId}/chapter/${index}`}
             state={{ backLink: BACK }}
         >
             <PlayArrow />


### PR DESCRIPTION
With the recent update to react-router-dom v6 the route "manga/:mangaId/chapter/:chapterIndex/page/:pageIndex" doesn't get matched anymore. The "pageIndex" is also unnecessary since it doesn't get used and instead the chapters "lastReadPage" property gets used to resume the chapter.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->