### PR TITLE
Do not use stale data for the reader

### DIFF
--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -107,6 +107,7 @@ export default function Reader() {
     const { data: chapter = initialChapter, isLoading: isChapterLoading } = requestManager.useGetChapter(
         mangaId,
         chapterIndex,
+        { disableCache: true },
     );
     const [wasLastPageReadSet, setWasLastPageReadSet] = useState(false);
     const [curPage, setCurPage] = useState<number>(0);
@@ -204,6 +205,7 @@ export default function Reader() {
             return;
         }
 
+        // do not mutate the chapter, this will cause the page to jump around due to always scrolling to the last read page
         if (curPage !== -1) {
             requestManager.updateChapter(manga.id, chapter.index, { lastPageRead: curPage });
         }


### PR DESCRIPTION
This caused the chapter to be loaded with stale data (the old lastPageRead state) and then jumping to the actual lastPageRead after the latest data was received.

It's not possible to mutate the chapter when updating lastPageRead since this causes the reader to always jump back to the just set lastPageRead when scrolling

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->