### PR TITLE
Prevent chapter revalidation on focus event in the Reader

### DIFF
--- a/src/screens/Reader.tsx
+++ b/src/screens/Reader.tsx
@@ -107,7 +107,7 @@ export default function Reader() {
     const { data: chapter = initialChapter, isLoading: isChapterLoading } = requestManager.useGetChapter(
         mangaId,
         chapterIndex,
-        { disableCache: true },
+        { disableCache: true, revalidateOnFocus: false },
     );
     const [wasLastPageReadSet, setWasLastPageReadSet] = useState(false);
     const [curPage, setCurPage] = useState<number>(0);


### PR DESCRIPTION
This caused the reader to scroll back to the beginning of the current page. And with the latest changes of 7f83bb9a0a9413d5b469025d82baf7198e36451f the loading state was shown.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->