### PR TITLE
Fix "hasNextPage" calculation for Library grid

### DIFF
--- a/src/components/library/LibraryMangaGrid.tsx
+++ b/src/components/library/LibraryMangaGrid.tsx
@@ -120,7 +120,7 @@ const LibraryMangaGrid: React.FC<LibraryMangaGridProps & { lastLibraryUpdate: nu
     const [query] = useQueryParam('query', StringParam);
     const { options } = useLibraryOptionsContext();
     const { unread, downloaded } = options;
-    const totalPages = (mangas ?? []).length / 10;
+    const totalPages = Math.trunc((mangas ?? []).length / 10);
     const theme = useTheme();
     const isLargeScreen = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
     const defaultPageNumber = isLargeScreen ? 4 : 1;


### PR DESCRIPTION
"totalPages" could have decimal places which then would lead the "hasNextPage" flag to be disabled

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->