### PR TITLE
Fix initial infinite swr request for pages > 1

### DIFF
--- a/src/lib/RequestManager.ts
+++ b/src/lib/RequestManager.ts
@@ -66,8 +66,9 @@ export type AbortableSWRInfiniteResponse<Data = any, Error = any> = SWRInfiniteR
 
 const isLoadingMore = (swrResult: SWRInfiniteResponse): boolean => {
     const isNextPageMissing = !!swrResult.data && typeof swrResult.data[swrResult.size - 1] === 'undefined';
+    const isRequestActive = swrResult.isValidating;
     // SWR "isLoading" state is only updated for the first load, for every subsequent load it's "false"
-    return !swrResult.isLoading && swrResult.size > 0 && isNextPageMissing;
+    return !swrResult.isLoading && swrResult.size > 0 && isNextPageMissing && isRequestActive;
 };
 
 const disableSwrInfiniteCache: Middleware = (useSWRNext) => (key, fetcher, config) => {


### PR DESCRIPTION
In case more than 1 page was requested for the initial request, there was a problem in case the first page already had no results. In that case the request for the second page always returned with the "isLoadMore" and "isLoading" flag set to true. Thus, incorrectly indicating that the request is still active. The "actual" request was already finished, but internally the "isLoadMore" flag was set incorrectly due to not considering if an actual request is active.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->