### PR TITLE
Use same endpoint for search in SearchAll and SourceMangas

### DIFF
--- a/src/screens/SearchAll.tsx
+++ b/src/screens/SearchAll.tsx
@@ -106,7 +106,7 @@ const SourceSearchPreview = React.memo(
             isLoading,
             error,
             abortRequest,
-        } = requestManager.useSourceSearch(id, searchString ?? '', 1, { skipRequest });
+        } = requestManager.useSourceQuickSearch(id, searchString ?? '', [], 1, { skipRequest });
         const mangas = !isLoading ? searchResult?.[0]?.mangaList ?? [] : [];
         const noMangasFound = !isLoading && !mangas.length;
 


### PR DESCRIPTION
SearchAll used a different search endpoint and thus, the already requested pages for the search weren't reused and instead had to be requested again since the swr cache key was different

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->