### PR TITLE
Never use "searchTerm" for "filter" source content type

### DIFF
--- a/src/screens/SourceMangas.tsx
+++ b/src/screens/SourceMangas.tsx
@@ -121,7 +121,7 @@ const useSourceManga = (
         case SourceContentType.FILTER:
             result = requestManager.useSourceQuickSearch(
                 sourceId,
-                searchTerm ?? '',
+                '',
                 filters.map((filter) => {
                     const { position, state, group } = filter;
 


### PR DESCRIPTION
There was an issue when switching from the "search" back to the "filter" source content type. The "filter" request returned the data from the search request and thus, showed invalid data until the correct data was loaded instead of showing the loading placeholder

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->