### PR TITLE
Always use available width for grid items

### DIFF
--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -34,7 +34,7 @@ const GridItemContainerWithDimension = (
     const columnsPerItem = gridLayout === GridLayout.List ? maxColumns : maxColumns / itemsPerRow;
 
     return ({ children, ...itemProps }: GridTypeMap['props'] & Partial<GridItemProps>) => (
-        <Grid {...itemProps} item xs={columnsPerItem} sx={{ paddingTop: '8px', paddingLeft: '8px' }}>
+        <Grid {...itemProps} item xs={columnsPerItem} sx={{ width: '100%', paddingTop: '8px', paddingLeft: '8px' }}>
             {children}
         </Grid>
     );


### PR DESCRIPTION
In case a manga thumbnail was smaller than the set item width, the item didn't use all its available width. Thus, being smaller than the other items.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->