### PR TITLE
Fix/library manga grid infinite item size on category switch

### DIFF
--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -176,7 +176,10 @@ const MangaGrid: React.FC<IMangaGridProps> = (props) => {
         inLibraryIndicator,
     } = props;
 
-    const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+    const [dimensions, setDimensions] = useState({
+        width: document.documentElement.offsetWidth,
+        height: document.documentElement.offsetHeight,
+    });
     const [gridItemWidth] = useLocalStorage<number>('ItemWidth', 300);
     const gridRef = useRef<HTMLDivElement>(null);
     const GridItemContainer = useMemo(
@@ -186,8 +189,8 @@ const MangaGrid: React.FC<IMangaGridProps> = (props) => {
 
     const updateGridWidth = () => {
         setDimensions({
-            width: gridRef.current?.offsetWidth ?? 0,
-            height: gridRef.current?.offsetHeight ?? 0,
+            width: gridRef.current?.offsetWidth ?? document.documentElement.offsetWidth,
+            height: gridRef.current?.offsetHeight ?? document.documentElement.offsetHeight,
         });
     };
 

--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -191,7 +191,7 @@ const MangaGrid: React.FC<IMangaGridProps> = (props) => {
         });
     };
 
-    useLayoutEffect(() => updateGridWidth, [gridRef.current?.offsetWidth, gridRef.current?.offsetHeight]);
+    useLayoutEffect(updateGridWidth, []);
 
     useEffect(() => {
         let movementTimer: NodeJS.Timeout;

--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -176,22 +176,16 @@ const MangaGrid: React.FC<IMangaGridProps> = (props) => {
         inLibraryIndicator,
     } = props;
 
-    const [dimensions, setDimensions] = useState({
-        width: document.documentElement.offsetWidth,
-        height: document.documentElement.offsetHeight,
-    });
+    const [dimensions, setDimensions] = useState(document.documentElement.offsetWidth);
     const [gridItemWidth] = useLocalStorage<number>('ItemWidth', 300);
     const gridRef = useRef<HTMLDivElement>(null);
     const GridItemContainer = useMemo(
-        () => GridItemContainerWithDimension(dimensions.width, gridItemWidth, gridLayout),
+        () => GridItemContainerWithDimension(dimensions, gridItemWidth, gridLayout),
         [dimensions, gridItemWidth, gridLayout],
     );
 
     const updateGridWidth = () => {
-        setDimensions({
-            width: gridRef.current?.offsetWidth ?? document.documentElement.offsetWidth,
-            height: gridRef.current?.offsetHeight ?? document.documentElement.offsetHeight,
-        });
+        setDimensions(gridRef.current?.offsetWidth ?? document.documentElement.offsetWidth);
     };
 
     useLayoutEffect(updateGridWidth, []);


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->