### PR TITLE
Enable changing include/exclude state of "default" category

### DIFF
--- a/src/screens/settings/LibrarySettings.tsx
+++ b/src/screens/settings/LibrarySettings.tsx
@@ -188,7 +188,6 @@ export default function LibrarySettings() {
                             <ThreeStateCheckboxInput
                                 key={category.id}
                                 label={category.name}
-                                disabled={category.name === 'Default'}
                                 checked={includeInUpdateStatusToBoolean(category.includeInUpdate)}
                                 onChange={(checked) => {
                                     const newIncludeState: IncludeInGlobalUpdate =


### PR DESCRIPTION
The "default" handling was changed, which makes it possible to change the include/exclude state

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->