### PR TITLE
Improvements on double page

### DIFF
--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -24,7 +24,7 @@ const isSinglePage = (index: number, spreadPages: boolean[]): boolean => {
     // Page is single if it is last page
     if (index === spreadPages.length - 1) return true;
     // Page can not be single if it is not followed by spread
-    if (!spreadPages[index + 1]) return false;
+    // if (!spreadPages[index + 1]) return false;
     // Page is single if number of single pages since last spread is odd
     const previousSpreadIndex = spreadPages.lastIndexOf(true, index - 1);
     const numberOfNonSpreads = index - (previousSpreadIndex + 1);
@@ -86,12 +86,7 @@ export default function DoublePagedPager(props: IReaderProps) {
 
     function pagesToGoBack() {
         // If previous page is single page, go only one page pack
-        // If previous page is not single page, but we are on last page
-        // go back one page anyway.
-        // This handles special case, where last page was displayed in pair, but then
-        // page was changed to the last page and now it is shown as single page.
-        const isLastPage = curPage === spreadPage.current.length - 1;
-        if (isSinglePage(curPage - 1, spreadPage.current) || isLastPage) {
+        if (isSinglePage(curPage - 1, spreadPage.current)) {
             return 1;
         }
 
@@ -100,7 +95,8 @@ export default function DoublePagedPager(props: IReaderProps) {
     }
 
     function nextPage() {
-        if (curPage < pages.length - 1) {
+        // Only go to next page if last page isn't displayed
+        if (curPage < pages.length - pagesDisplayed.current) {
             const nextCurPage = curPage + pagesDisplayed.current;
             setCurPage(nextCurPage >= pages.length ? pages.length - 1 : nextCurPage);
         } else if (settings.loadNextOnEnding) {

--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -93,7 +93,6 @@ export default function DoublePagedPager(props: IReaderProps) {
     }
 
     function nextPage() {
-        // Only go to next page if last page isn't displayed
         if (curPage < pages.length - 1) {
             const nextCurPage = curPage + pagesDisplayed.current;
             setCurPage(nextCurPage >= pages.length ? pages.length - 1 : nextCurPage);

--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -94,7 +94,7 @@ export default function DoublePagedPager(props: IReaderProps) {
 
     function nextPage() {
         // Only go to next page if last page isn't displayed
-        if (curPage < pages.length - pagesDisplayed.current) {
+        if (curPage < pages.length - 1) {
             const nextCurPage = curPage + pagesDisplayed.current;
             setCurPage(nextCurPage >= pages.length ? pages.length - 1 : nextCurPage);
         } else if (settings.loadNextOnEnding) {

--- a/src/components/reader/pager/DoublePagedPager.tsx
+++ b/src/components/reader/pager/DoublePagedPager.tsx
@@ -23,8 +23,6 @@ const isSinglePage = (index: number, spreadPages: boolean[]): boolean => {
     if (spreadPages[index]) return true;
     // Page is single if it is last page
     if (index === spreadPages.length - 1) return true;
-    // Page can not be single if it is not followed by spread
-    // if (!spreadPages[index + 1]) return false;
     // Page is single if number of single pages since last spread is odd
     const previousSpreadIndex = spreadPages.lastIndexOf(true, index - 1);
     const numberOfNonSpreads = index - (previousSpreadIndex + 1);

--- a/versionToServerVersionMapping.json
+++ b/versionToServerVersionMapping.json
@@ -1,6 +1,6 @@
 [
   {
     "uiVersion": "PREVIEW",
-    "serverVersion": "r1353"
+    "serverVersion": "r1354"
   }
 ]

--- a/versionToServerVersionMapping.json
+++ b/versionToServerVersionMapping.json
@@ -1,6 +1,6 @@
 [
   {
     "uiVersion": "PREVIEW",
-    "serverVersion": "r1354"
+    "serverVersion": "r1353"
   }
 ]


### PR DESCRIPTION
This pull request changes how the double page works a bit. 

First, when there are two pages showing and the second page is the last page, it stops/goes to the next chapter.

Second, going to previous page has been improved as before, if you were on the last page and it was a double spread, it would make the last page single even if that wasn't correct.

This closes no issues

