### PR TITLE
Do not add mangas to the default category

### DIFF
--- a/src/components/manga/MangaDetails.tsx
+++ b/src/components/manga/MangaDetails.tsx
@@ -169,7 +169,9 @@ export const MangaDetails: React.FC<IProps> = ({ manga }) => {
     const { t } = useTranslation();
     const { data: categoriesData, loading: areCategoriesLoading } = requestManager.useGetCategories();
     const categories = categoriesData?.categories.nodes ?? [];
-    const defaultCategoryIds = categories.filter((category) => category.default).map((category) => category.id);
+    const defaultCategoryIds = categories
+        .filter((category) => category.default && category.id !== 0)
+        .map((category) => category.id);
     const [updateMangaCategories] = requestManager.useUpdateMangaCategories();
 
     useEffect(() => {


### PR DESCRIPTION
The default category is used as a fallback and should never be actually mapped to mangas in the database. However, when using the update manga category mutation the server still creates this mapping which then leads to issues with getting mangas for the default category

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->