### PR TITLE
Handle source browse when first page is also the last page

### DIFF
--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -955,7 +955,9 @@ export class RequestManager {
             getVariablesFor(0),
         );
 
-        const areInitialPagesFetched = cachedResults.length >= initialPages;
+        const areInitialPagesFetched =
+            cachedResults.length >= initialPages ||
+            (!!cachedResults.length && !cachedResults[cachedResults.length - 1].data?.fetchSourceManga.hasNextPage);
         const isResultForCurrentInput = result?.forInput === JSON.stringify(getVariablesFor(0));
         const lastPage = cachedPages.size ? Math.max(...cachedPages) : input.page;
         const nextPage = isResultForCurrentInput ? result.size : lastPage;


### PR DESCRIPTION
In case the first page was also the last page, there is no next page that can be fetched. On large screens, where the initial pages to fetch are 2, this resulted in an endless loading screen

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->