### PR TITLE
Prevent SelectionFAB from being behind the "ChapterCard" checkbox

### DIFF
--- a/src/components/manga/SelectionFAB.tsx
+++ b/src/components/manga/SelectionFAB.tsx
@@ -42,6 +42,7 @@ export const SelectionFAB: React.FC<SelectionFABProps> = (props) => {
                 ...DEFAULT_FAB_STYLE,
                 height: `calc(${DEFAULT_FAB_STYLE.height} + 1)`,
                 pt: 1,
+                zIndex: 1, // the "Checkbox" (MUI) component of the "ChapterCard" has z-index 1, which causes it to take over the mouse events
             }}
             ref={anchorEl}
         >


### PR DESCRIPTION
The MUI Checkbox component has a z-index of 1, which causes it to register the mouse events instead of the "SelectionFAB" which is visually in front of it

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->