### PR TITLE
Remove re-fetching of manga query on chapter update

### DIFF
--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -1425,7 +1425,7 @@ export class RequestManager {
             GQLMethod.MUTATION,
             UPDATE_CHAPTER,
             { input: { id, patch } },
-            { refetchQueries: [GET_MANGA], ...options },
+            options,
         );
     }
 


### PR DESCRIPTION
The mutation returns the mutated manga, thus, updating the cache which makes this  refetch unnecessary and just creates redundant requests.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->