### PR TITLE
Persist server settings when disabling them

### DIFF
--- a/src/util/usePersistedValue.tsx
+++ b/src/util/usePersistedValue.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useLocalStorage } from '@/util/useLocalStorage.tsx';
+
+export const getPersistedServerSetting = <T,>(serverValue: T | undefined, lastValue: T): T => {
+    const isDisabled = serverValue === 0;
+    if (isDisabled) {
+        return lastValue;
+    }
+
+    return serverValue ?? lastValue;
+};
+
+export const usePersistedValue = <T,>(
+    key: string,
+    defaultValue: T,
+    currentValue: T | undefined,
+    getCurrentValue: (currentValue: T | undefined, persistedValue: T) => T,
+): [T, (value: T) => void] => {
+    const [persistedValue, setPersistedValue] = useLocalStorage(key, defaultValue);
+
+    const value = getCurrentValue(currentValue, persistedValue);
+
+    return [value, setPersistedValue];
+};


### PR DESCRIPTION
Some settings use 0 as the disabled state.
In this case, the previous enabled value was lost. To prevent this, the last value now gets saved and set again when enabling the setting again

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->