### PR TITLE
Remove "directLink" prop

### DIFF
--- a/src/components/util/ListItemLink.tsx
+++ b/src/components/util/ListItemLink.tsx
@@ -9,15 +9,6 @@
 import { Link } from 'react-router-dom';
 import { ListItemButton, ListItemButtonProps } from '@mui/material';
 
-export function ListItemLink(props: ListItemButtonProps<typeof Link, { directLink?: boolean }>) {
-    const { directLink, to } = props;
-    if (directLink) {
-        if (typeof to !== 'string') {
-            throw new Error('ListItemLink: "to" has to be a string in case it is a directLink');
-        }
-
-        return <ListItemButton component="a" href={to} {...props} />;
-    }
-
+export function ListItemLink(props: ListItemButtonProps<typeof Link>) {
     return <ListItemButton component={Link} {...props} />;
 }

--- a/src/screens/settings/About.tsx
+++ b/src/screens/settings/About.tsx
@@ -93,16 +93,16 @@ export function About() {
                     </ListSubheader>
                 }
             >
-                <ListItemLink directLink to={aboutServer.github}>
+                <ListItemLink to={aboutServer.github}>
                     <ListItemText primary={t('settings.about.server.label.github')} secondary={aboutServer.github} />
                 </ListItemLink>
-                <ListItemLink directLink to="https://github.com/Suwayomi/Tachidesk-WebUI">
+                <ListItemLink to="https://github.com/Suwayomi/Tachidesk-WebUI">
                     <ListItemText
                         primary={t('settings.about.webui.label.github')}
                         secondary="https://github.com/Suwayomi/Tachidesk-WebUI"
                     />
                 </ListItemLink>
-                <ListItemLink directLink to={aboutServer.discord}>
+                <ListItemLink to={aboutServer.discord}>
                     <ListItemText primary={t('global.label.discord')} secondary={aboutServer.discord} />
                 </ListItemLink>
             </List>

--- a/src/screens/settings/Backup.tsx
+++ b/src/screens/settings/Backup.tsx
@@ -161,7 +161,7 @@ export function Backup() {
     return (
         <>
             <List sx={{ padding: 0 }}>
-                <ListItemLink to={requestManager.getExportBackupUrl()} directLink>
+                <ListItemLink to={requestManager.getExportBackupUrl()}>
                     <ListItemText
                         primary={t('settings.backup.label.create_backup')}
                         secondary={t('settings.backup.label.create_backup_info')}


### PR DESCRIPTION
Is not required anymore since "Link" of react-router-dom is a "<a>" element now anyway. It also caused the following warning

"react-dom.development.js:86  Warning: React does not recognize the `directLink` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `directlink` instead. If you accidentally passed it from a parent component, remove it from the DOM element"

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->