### PR TITLE
Scroll to top when changing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,8 @@
 
 import { Container } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
-import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import React, { useLayoutEffect } from 'react';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev';
 import { __DEV__ } from '@apollo/client/utilities/globals';
 import { AppContext } from '@/components/context/AppContext';
@@ -42,8 +42,20 @@ if (__DEV__) {
     loadDevMessages();
     loadErrorMessages();
 }
+
+const ScrollToTop = () => {
+    const { pathname } = useLocation();
+
+    useLayoutEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+};
+
 export const App: React.FC = () => (
     <AppContext>
+        <ScrollToTop />
         <ServerUpdateChecker />
         <CssBaseline />
         <DefaultNavBar />


### PR DESCRIPTION
The scroll position was persisted when switching to a different page. Thus, when the current page was scrolled down and the next page was also scrollable, the top of the new page was not visible

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->