### PR TITLE
Remove unnecessary library refetch

### DIFF
--- a/src/screens/Library.tsx
+++ b/src/screens/Library.tsx
@@ -7,7 +7,7 @@
  */
 
 import { Chip, Tab, Tabs, styled, Box } from '@mui/material';
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { useQueryParam, NumberParam } from 'use-query-params';
 import { useTranslation } from 'react-i18next';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
@@ -66,7 +66,6 @@ export function Library() {
         data: categoriesResponse,
         error: tabsError,
         loading: areCategoriesLoading,
-        refetch,
     } = requestManager.useGetCategories();
     const tabsData = categoriesResponse?.categories.nodes.filter(
         (category) => category.id !== 0 || (category.id === 0 && category.mangas.totalCount),
@@ -87,10 +86,6 @@ export function Library() {
     } = requestManager.useGetCategoryMangas(activeTab?.id, { skip: !activeTab, nextFetchPolicy: 'cache-only' });
     const mangas = categoryMangaResponse?.mangas.nodes ?? [];
 
-    const handleFinishedUpdate = useCallback(() => {
-        refetch();
-    }, [refetch]);
-
     const { setTitle, setAction } = useContext(NavBarContext);
     useEffect(() => {
         const title = t('library.title');
@@ -105,7 +100,7 @@ export function Library() {
             <>
                 <AppbarSearch />
                 <LibraryToolbarMenu />
-                <UpdateChecker handleFinishedUpdate={handleFinishedUpdate} />
+                <UpdateChecker />
             </>,
         );
         return () => {


### PR DESCRIPTION
The server is now returning up-to-date manga data and thus, it's not necessary to refetch the library anymore after the update is finished

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->