### PR TITLE
Cancel the navigation state update correctly

### DIFF
--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -103,7 +103,7 @@ const VerticalGrid = ({
             );
         }, 250);
     };
-    useEffect(() => clearTimeout(persistGridStateTimeout.current), []);
+    useEffect(() => clearTimeout(persistGridStateTimeout.current), [location.key, persistGridStateTimeout.current]);
 
     return (
         <>


### PR DESCRIPTION
The timeout was never canceled in case the tab changed, thus, it kept updating the navigation state for the previous tab and the new tab.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->