### PR TITLE
Prevent ApolloError handling the manga category mutation result

### DIFF
--- a/src/lib/graphql/generated/graphql.ts
+++ b/src/lib/graphql/generated/graphql.ts
@@ -2446,14 +2446,14 @@ export type UpdateMangaCategoriesMutationVariables = Exact<{
 }>;
 
 
-export type UpdateMangaCategoriesMutation = { __typename?: 'Mutation', updateMangaCategories: { __typename?: 'UpdateMangaCategoriesPayload', clientMutationId?: string | null, manga: { __typename?: 'MangaType', id: number, categories: { __typename?: 'CategoryNodeList', nodes: Array<{ __typename?: 'CategoryType', id: number, mangas: { __typename?: 'MangaNodeList', totalCount: number } }> } } } };
+export type UpdateMangaCategoriesMutation = { __typename?: 'Mutation', updateMangaCategories: { __typename?: 'UpdateMangaCategoriesPayload', clientMutationId?: string | null, manga: { __typename?: 'MangaType', id: number, categories: { __typename?: 'CategoryNodeList', totalCount: number, nodes: Array<{ __typename?: 'CategoryType', id: number, mangas: { __typename?: 'MangaNodeList', totalCount: number } }> } } } };
 
 export type UpdateMangasCategoriesMutationVariables = Exact<{
   input: UpdateMangasCategoriesInput;
 }>;
 
 
-export type UpdateMangasCategoriesMutation = { __typename?: 'Mutation', updateMangasCategories: { __typename?: 'UpdateMangasCategoriesPayload', clientMutationId?: string | null, mangas: Array<{ __typename?: 'MangaType', id: number, categories: { __typename?: 'CategoryNodeList', nodes: Array<{ __typename?: 'CategoryType', id: number, mangas: { __typename?: 'MangaNodeList', totalCount: number } }> } }> } };
+export type UpdateMangasCategoriesMutation = { __typename?: 'Mutation', updateMangasCategories: { __typename?: 'UpdateMangasCategoriesPayload', clientMutationId?: string | null, mangas: Array<{ __typename?: 'MangaType', id: number, categories: { __typename?: 'CategoryNodeList', totalCount: number, nodes: Array<{ __typename?: 'CategoryType', id: number, mangas: { __typename?: 'MangaNodeList', totalCount: number } }> } }> } };
 
 export type UpdateWebuiMutationVariables = Exact<{
   input?: InputMaybe<WebUiUpdateInput>;

--- a/src/lib/graphql/mutations/MangaMutation.ts
+++ b/src/lib/graphql/mutations/MangaMutation.ts
@@ -106,6 +106,7 @@ export const UPDATE_MANGA_CATEGORIES = gql`
                             totalCount
                         }
                     }
+                    totalCount
                 }
             }
         }
@@ -125,6 +126,7 @@ export const UPDATE_MANGAS_CATEGORIES = gql`
                             totalCount
                         }
                     }
+                    totalCount
                 }
             }
         }


### PR DESCRIPTION
Unclear what is causing the error or why this is fixing it, but without requesting the categories total count, the mutation fails on the first execution with "Uncaught (in promise) ApolloError: Cannot convert object to primitive value"

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->