### PR TITLE
Prevent navigation state update in case path already changed

### DIFF
--- a/src/components/MangaGrid.tsx
+++ b/src/components/MangaGrid.tsx
@@ -95,8 +95,15 @@ const VerticalGrid = ({
 
     const persistGridStateTimeout = useRef<NodeJS.Timeout | undefined>();
     const persistGridState = (gridState: GridStateSnapshot) => {
+        const currentUrl = window.location.href;
+
         clearTimeout(persistGridStateTimeout.current);
         persistGridStateTimeout.current = setTimeout(() => {
+            const didLocationChange = currentUrl !== window.location.href;
+            if (didLocationChange) {
+                return;
+            }
+
             navigate(
                 { pathname: '', search: location.search },
                 { replace: true, state: { ...location.state, snapshot: gridState } },


### PR DESCRIPTION
The fix of e4beafb11f1ee9dd4f464e7d627e40d58dad2115 only worked in dev env and not in prod. This prevents the navigation state update from getting triggered in case the path has changed in the meantime

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->