### PR TITLE
[Codegen] Check cache before executing query for a single item

### DIFF
--- a/src/lib/graphql/generated/apollo-helpers.ts
+++ b/src/lib/graphql/generated/apollo-helpers.ts
@@ -1,5 +1,10 @@
-import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
-import { GetChaptersQuery } from "@/lib/graphql/generated/graphql.ts";
+import {FieldPolicy, FieldReadFunction, Reference, TypePolicies, TypePolicy} from '@apollo/client/cache';
+import {
+	GetCategoryQueryVariables, GetChapterQueryVariables,
+	GetChaptersQuery, GetExtensionQueryVariables, GetGlobalMetadataQueryVariables,
+	GetMangaQueryVariables, GetSourceQueryVariables,
+} from "@/lib/graphql/generated/graphql.ts";
+import {FieldFunctionOptions} from "@apollo/client/cache/inmemory/policies";
 export type AboutServerPayloadKeySpecifier = ('buildTime' | 'buildType' | 'discord' | 'github' | 'name' | 'revision' | 'version' | AboutServerPayloadKeySpecifier)[];
 export type AboutServerPayloadFieldPolicy = {
 	buildTime?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -508,23 +513,23 @@ export type QueryKeySpecifier = ('aboutServer' | 'aboutWebUI' | 'categories' | '
 export type QueryFieldPolicy = {
 	about?: FieldPolicy<any> | FieldReadFunction<any>,
 	categories?: FieldPolicy<any> | FieldReadFunction<any>,
-	category?: FieldPolicy<any> | FieldReadFunction<any>,
-	chapter?: FieldPolicy<any> | FieldReadFunction<any>,
+	category?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetCategoryQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetCategoryQueryVariables>>,
+	chapter?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetChapterQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetChapterQueryVariables>>,
 	chapters?: FieldPolicy<GetChaptersQuery['chapters']> | FieldReadFunction<GetChaptersQuery['chapters']>,
 	checkForServerUpdates?: FieldPolicy<any> | FieldReadFunction<any>,
 	checkForWebUIUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 	downloadStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-	extension?: FieldPolicy<any> | FieldReadFunction<any>,
+	extension?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetExtensionQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetExtensionQueryVariables>>,
 	extensions?: FieldPolicy<any> | FieldReadFunction<any>,
 	getWebUIUpdateStatus?: FieldPolicy<any> | FieldReadFunction<any>,
 	lastUpdateTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-	manga?: FieldPolicy<any> | FieldReadFunction<any>,
+	manga?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetMangaQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetMangaQueryVariables>>,
 	mangas?: FieldPolicy<any> | FieldReadFunction<any>,
-	meta?: FieldPolicy<any> | FieldReadFunction<any>,
+	meta?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetGlobalMetadataQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetGlobalMetadataQueryVariables>>,
 	metas?: FieldPolicy<any> | FieldReadFunction<any>,
 	restoreStatus?: FieldPolicy<any> | FieldReadFunction<any>,
 	settings?: FieldPolicy<any> | FieldReadFunction<any>,
-	source?: FieldPolicy<any> | FieldReadFunction<any>,
+	source?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetSourceQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetSourceQueryVariables>>,
 	sources?: FieldPolicy<any> | FieldReadFunction<any>,
 	updateStatus?: FieldPolicy<any> | FieldReadFunction<any>,
 	validateBackup?: FieldPolicy<any> | FieldReadFunction<any>

--- a/src/lib/requests/client/GraphQLClient.ts
+++ b/src/lib/requests/client/GraphQLClient.ts
@@ -11,6 +11,7 @@ import { createUploadLink } from 'apollo-upload-client';
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
 import { Client, createClient } from 'graphql-ws';
 import { getMainDefinition } from '@apollo/client/utilities';
+import { TypePolicies } from '@apollo/client/cache';
 import { BaseClient } from '@/lib/requests/client/BaseClient.ts';
 import { StrictTypedTypePolicies } from '@/lib/graphql/generated/apollo-helpers.ts';
 
@@ -27,9 +28,40 @@ const typePolicies: StrictTypedTypePolicies = {
     DownloadType: { keyFields: ['chapter'] },
     Query: {
         fields: {
+            manga(_, { args, toReference }) {
+                return toReference({
+                    __typename: 'MangaType',
+                    id: args?.id,
+                });
+            },
+            category(_, { args, toReference }) {
+                return toReference({
+                    __typename: 'CategoryType',
+                    id: args?.id,
+                });
+            },
+            source(_, { args, toReference }) {
+                return toReference({
+                    __typename: 'SourceType',
+                    id: args?.id,
+                });
+            },
+            extension(_, { args, toReference }) {
+                return toReference({
+                    __typename: 'ExtensionType',
+                    apkName: args?.pkgName,
+                });
+            },
+            meta(_, { args, toReference }) {
+                return toReference({
+                    __typename: 'GlobalMetaType',
+                    key: args?.key,
+                });
+            },
             chapters: {
                 keyArgs: ['condition', 'filter', 'orderBy', 'orderByType'],
                 merge(existing, incoming) {
+                    console.log('merge chapters', { ...existing }, { ...incoming });
                     if (existing == null) {
                         return incoming;
                     }
@@ -116,7 +148,12 @@ export class GraphQLClient extends BaseClient<
 
         this.client = new ApolloClient({
             cache: new InMemoryCache({
-                typePolicies,
+                // for whatever reason there is some weird TypeError complaining that
+                // "FieldReadFunction<Reference, Reference, FieldFunctionOptions<SomeObject, Record<string, any>>"
+                // is not compatible with "FieldReadFunction<any, any, FieldFunctionOptions<Record<string, any, Record<string, any>>"
+                // Since "typePolicies" is correctly typed as StrictTypedTypePolicies, and it is working as expected,
+                // the TypeError can just be ignored
+                typePolicies: typePolicies as TypePolicies,
             }),
             connectToDevTools: true,
             link: this.createLink(),

--- a/tools/scripts/codegenFormatter.ts
+++ b/tools/scripts/codegenFormatter.ts
@@ -51,8 +51,13 @@ generatedGraphQLFile = fs.readFileSync(generatedGraphQLFilePath, 'utf8');
 const addImports = format(
     generatedGraphQLFile,
     `import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';`,
-    `import { FieldPolicy, FieldReadFunction, TypePolicies, TypePolicy } from '@apollo/client/cache';
-import { GetChaptersQuery } from "@/lib/graphql/generated/graphql.ts";`,
+    `import {FieldPolicy, FieldReadFunction, Reference, TypePolicies, TypePolicy} from '@apollo/client/cache';
+import {
+\tGetCategoryQueryVariables, GetChapterQueryVariables,
+\tGetChaptersQuery, GetExtensionQueryVariables, GetGlobalMetadataQueryVariables,
+\tGetMangaQueryVariables, GetSourceQueryVariables,
+} from "@/lib/graphql/generated/graphql.ts";
+import {FieldFunctionOptions} from "@apollo/client/cache/inmemory/policies";`,
 );
 
 const fixTypingOfQueryTypePolicies = format(
@@ -85,23 +90,23 @@ const fixTypingOfQueryTypePolicies = format(
     `export type QueryFieldPolicy = {
 \tabout?: FieldPolicy<any> | FieldReadFunction<any>,
 \tcategories?: FieldPolicy<any> | FieldReadFunction<any>,
-\tcategory?: FieldPolicy<any> | FieldReadFunction<any>,
-\tchapter?: FieldPolicy<any> | FieldReadFunction<any>,
+\tcategory?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetCategoryQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetCategoryQueryVariables>>,
+\tchapter?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetChapterQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetChapterQueryVariables>>,
 \tchapters?: FieldPolicy<GetChaptersQuery['chapters']> | FieldReadFunction<GetChaptersQuery['chapters']>,
 \tcheckForServerUpdates?: FieldPolicy<any> | FieldReadFunction<any>,
 \tcheckForWebUIUpdate?: FieldPolicy<any> | FieldReadFunction<any>,
 \tdownloadStatus?: FieldPolicy<any> | FieldReadFunction<any>,
-\textension?: FieldPolicy<any> | FieldReadFunction<any>,
+\textension?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetExtensionQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetExtensionQueryVariables>>,
 \textensions?: FieldPolicy<any> | FieldReadFunction<any>,
 \tgetWebUIUpdateStatus?: FieldPolicy<any> | FieldReadFunction<any>,
 \tlastUpdateTimestamp?: FieldPolicy<any> | FieldReadFunction<any>,
-\tmanga?: FieldPolicy<any> | FieldReadFunction<any>,
+\tmanga?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetMangaQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetMangaQueryVariables>>,
 \tmangas?: FieldPolicy<any> | FieldReadFunction<any>,
-\tmeta?: FieldPolicy<any> | FieldReadFunction<any>,
+\tmeta?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetGlobalMetadataQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetGlobalMetadataQueryVariables>>,
 \tmetas?: FieldPolicy<any> | FieldReadFunction<any>,
 \trestoreStatus?: FieldPolicy<any> | FieldReadFunction<any>,
 \tsettings?: FieldPolicy<any> | FieldReadFunction<any>,
-\tsource?: FieldPolicy<any> | FieldReadFunction<any>,
+\tsource?: FieldPolicy<Reference, Reference, Reference, FieldFunctionOptions<GetSourceQueryVariables>> | FieldReadFunction<Reference, Reference, FieldFunctionOptions<GetSourceQueryVariables>>,
 \tsources?: FieldPolicy<any> | FieldReadFunction<any>,
 \tupdateStatus?: FieldPolicy<any> | FieldReadFunction<any>,
 \tvalidateBackup?: FieldPolicy<any> | FieldReadFunction<any>


### PR DESCRIPTION
E.g. in case a manga was already loaded through the category mangas query, the query for that specific manga should not run against the server if it hasn't been executed before

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->