### PR TITLE
[Codegen] Request manga download count with chapter deletion mutation

### DIFF
--- a/src/lib/graphql/generated/graphql.ts
+++ b/src/lib/graphql/generated/graphql.ts
@@ -2292,14 +2292,14 @@ export type DeleteDownloadedChapterMutationVariables = Exact<{
 }>;
 
 
-export type DeleteDownloadedChapterMutation = { __typename?: 'Mutation', deleteDownloadedChapter: { __typename?: 'DeleteDownloadedChapterPayload', clientMutationId?: string | null, chapters: { __typename?: 'ChapterType', id: number, isDownloaded: boolean } } };
+export type DeleteDownloadedChapterMutation = { __typename?: 'Mutation', deleteDownloadedChapter: { __typename?: 'DeleteDownloadedChapterPayload', clientMutationId?: string | null, chapters: { __typename?: 'ChapterType', id: number, isDownloaded: boolean, manga: { __typename?: 'MangaType', id: number, downloadCount: number } } } };
 
 export type DeleteDownloadedChaptersMutationVariables = Exact<{
   input: DeleteDownloadedChaptersInput;
 }>;
 
 
-export type DeleteDownloadedChaptersMutation = { __typename?: 'Mutation', deleteDownloadedChapters: { __typename?: 'DeleteDownloadedChaptersPayload', clientMutationId?: string | null, chapters: Array<{ __typename?: 'ChapterType', id: number, isDownloaded: boolean }> } };
+export type DeleteDownloadedChaptersMutation = { __typename?: 'Mutation', deleteDownloadedChapters: { __typename?: 'DeleteDownloadedChaptersPayload', clientMutationId?: string | null, chapters: Array<{ __typename?: 'ChapterType', id: number, isDownloaded: boolean, manga: { __typename?: 'MangaType', id: number, downloadCount: number } }> } };
 
 export type DequeueChapterDownloadMutationVariables = Exact<{
   input: DequeueChapterDownloadInput;

--- a/src/lib/graphql/mutations/DownloaderMutation.ts
+++ b/src/lib/graphql/mutations/DownloaderMutation.ts
@@ -28,6 +28,10 @@ export const DELETE_DOWNLOADED_CHAPTER = gql`
             chapters {
                 id
                 isDownloaded
+                manga {
+                    id
+                    downloadCount
+                }
             }
         }
     }
@@ -40,6 +44,10 @@ export const DELETE_DOWNLOADED_CHAPTERS = gql`
             chapters {
                 id
                 isDownloaded
+                manga {
+                    id
+                    downloadCount
+                }
             }
         }
     }


### PR DESCRIPTION
After deleting a chapter, the download count of the chapters manga did not update, because the information was not requested with the mutation

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->