### PR TITLE
Allow browser context menu for images in reader

### DIFF
--- a/src/components/reader/Page.tsx
+++ b/src/components/reader/Page.tsx
@@ -45,7 +45,6 @@ function imageStyle(settings: IReaderSettings): any {
             height: 'auto',
             maxHeight: '99vh',
             objectFit: 'contain',
-            pointerEvents: 'none',
         };
     }
 
@@ -55,7 +54,6 @@ function imageStyle(settings: IReaderSettings): any {
         minWidth: '50vw',
         width: dimensions.width < dimensions.height ? '100vw' : '100%',
         maxWidth: '100%',
-        pointerEvents: 'none',
     };
 }
 

--- a/src/components/util/SpinnerImage.tsx
+++ b/src/components/util/SpinnerImage.tsx
@@ -59,7 +59,7 @@ export function SpinnerImage(props: IProps) {
         return <Box sx={spinnerStyle} />;
     }
 
-    return <img style={imgStyle} ref={imgRef} src={imageSrc} alt={alt} />;
+    return <img style={imgStyle} ref={imgRef} src={imageSrc} alt={alt} draggable={false} />;
 }
 
 SpinnerImage.defaultProps = {


### PR DESCRIPTION
The changes of dabe88385d0ff1017eea6e3df9d620cc6550e33f removed the ability to copy/open images in a new tab due to enabling scrolling via left mouse click and dragging the mouse.

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->