### PR TITLE
Pass correct group sizes to "GroupedVirtuoso"

### DIFF
--- a/src/screens/Extensions.tsx
+++ b/src/screens/Extensions.tsx
@@ -135,7 +135,7 @@ export function Extensions() {
     );
 
     const groupCounts = useMemo(
-        () => filteredGroupedExtensions.map((extensionGroup) => extensionGroup[EXTENSIONS].length - 1),
+        () => filteredGroupedExtensions.map((extensionGroup) => extensionGroup[EXTENSIONS].length),
         [filteredGroupedExtensions],
     );
     const visibleExtensions = useMemo(


### PR DESCRIPTION
One item was always hidden from the list.
Noticed during searching for a specific extension, which caused the list to only have one item, which was not shown

Was incorrectly changed with db65b9df44521cb78e76c64328a308e071b65aac

<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->