### PR TITLE
[skipCI] fix typo of suwayomi ui version

### DIFF
--- a/versionToServerVersionMapping.json
+++ b/versionToServerVersionMapping.json
@@ -5,7 +5,7 @@
   },
   {
     "tag": "OLD_PREVIEW",
-    "uiVersion": "r2845",
+    "uiVersion": "r2846",
     "serverVersion": "r1941"
   },
   {


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->
I'm a mantainer of PKGBUILD of Suwayomi-Server-Preview in Arch Linux and today when I started to check if there was any updates, the UI alerts it could not download the new version. Checking the logs of server I got this:

```
11:07:02.455 [DefaultDispatcher-worker-9] WARN suwayomi.tachidesk.server.util.WebInterfaceManager downloadVersion(version= r2845, flavor= WebUI) -- (retry 1/3) failed due to
java.io.FileNotFoundException: https://github.com/Suwayomi/Suwayomi-WebUI-preview/releases/download/r2845/Suwayomi-WebUI-r2845.zip
```

Checking if there was a r2845 version at Suwayomi-UI-Preview I noticed that it doesn't exist, so this PR just fix this typo.