### PR TITLE
Add dynamic theme-color meta for immersive Android experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,16 @@
 
     if (backgroundColor) {
         document.documentElement.style.backgroundColor = backgroundColor;
+        // android chromium-based browser/pwa background color (e.g. top status bar and navigation bar) will change dynamically based on meta theme-color
+        let themeColorMeta = document.querySelector('meta[name="theme-color"]');
+        if (!themeColorMeta) {
+            themeColorMeta = document.createElement('meta');
+            themeColorMeta.setAttribute('name', 'theme-color');
+            document.head.appendChild(themeColorMeta);
+        }
+        if (themeColorMeta.getAttribute('content') !== backgroundColor) {
+            themeColorMeta.setAttribute('content', backgroundColor);
+        }
     }
 </script>
 <!--

--- a/src/features/theme/AppThemeContext.tsx
+++ b/src/features/theme/AppThemeContext.tsx
@@ -131,8 +131,19 @@ export const AppThemeContextProvider = ({ children }: { children: ReactNode }) =
     useEffect(() => {
         // The set background color is not necessary anymore, since the theme has been loaded
         document.documentElement.style.backgroundColor = '';
+        const themeBackgroundColor = theme.palette.background.default;
 
-        AppStorage.local.setItem('theme_background', theme.palette.background.default);
+        AppStorage.local.setItem('theme_background', themeBackgroundColor);
+        // android chromium-based browser/pwa background color (e.g. top status bar and navigation bar) will change dynamically based on meta theme-color
+        let themeColorMeta = document.querySelector('meta[name="theme-color"]');
+        if (!themeColorMeta) {
+            themeColorMeta = document.createElement('meta');
+            themeColorMeta.setAttribute('name', 'theme-color');
+            document.head.appendChild(themeColorMeta);
+        }
+        if (themeColorMeta.getAttribute('content') !== themeBackgroundColor) {
+            themeColorMeta.setAttribute('content', themeBackgroundColor);
+        }
     }, [theme.palette.background.default]);
 
     if (directionRef.current !== currentDirection) {


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the rational behind the changes
- Include enough before and after images if there are visual changes
- Mention all issues the pull request is closing 
-->

Different from iOS devices (especially iOS Safari after iOS 26), Android browsers and PWAs do not automatically collect mobile app background colors, which is not conducive to immersive reading:

 - Without `theme-color meta`, Android Browsers (e.g. Chrome) use the default theme color of the browser
 - Without `theme-color meta`, Android PWAs use the background color in manifest.json

This PR's change uses `<meta name="theme-color" content="#theme_background">` to dynamically set the browser theme color, providing a better immersive reading experience for Android devices. The following table shows the before and after comparison:

 
| Enviroment               | Theme  | Before | After |
|--------------------------|--------|--------|-------|
| Android Browser (Chrome) | Dark   | <img width="300" height="652" alt="chrome dark before screenshot" src="https://github.com/user-attachments/assets/4cbe414c-d699-4361-a544-faae2f2660d5" /> |  <img width="300" height="652" alt="chrome dark after screenshot" src="https://github.com/user-attachments/assets/e3c3f8f7-6451-403c-81e7-33bbd392066c" />     |
| Android Browser (Chrome) | Light  | <img width="300" height="652" alt="chrome light before screenshot" src="https://github.com/user-attachments/assets/31483fee-5e97-4cf2-a17e-f05011435d15" />       |  <img width="300" height="652" alt="chrome light after screenshot" src="https://github.com/user-attachments/assets/6a5ca796-454d-464f-aca0-0aca732b0d41" />     |
| Android PWA              | Dark   |  <img width="300" height="652" alt="pwa dark before screenshot" src="https://github.com/user-attachments/assets/da629696-c39c-4e4b-a4ea-e47fd4760c69" />      |   <img width="300" height="652" alt="pwa dark after screenshot" src="https://github.com/user-attachments/assets/60da36f6-e362-4d5e-935d-6fe3c2fd20c9" />    |
| Android PWA              | Light  |   <img width="300" height="652" alt="pwa light before screenshot" src="https://github.com/user-attachments/assets/78e335f9-0c64-417c-a1e0-539c58ee6627" />     |   <img width="300" height="652" alt="pwa light after screenshot" src="https://github.com/user-attachments/assets/d1c6cbbe-1ced-427b-be15-ee63c6078499" />    |