### PR TITLE
feat: add Edit Metadata dialog with cover upload and provider matching

### DIFF
--- a/src/features/manga/components/details/EditMangaMetadataDialog.tsx
+++ b/src/features/manga/components/details/EditMangaMetadataDialog.tsx
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Autocomplete from '@mui/material/Autocomplete';
+import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import CardMedia from '@mui/material/CardMedia';
+import CircularProgress from '@mui/material/CircularProgress';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import SearchIcon from '@mui/icons-material/Search';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { useLingui } from '@lingui/react/macro';
+import { requestManager } from '@/lib/requests/RequestManager.ts';
+import { MangaStatus } from '@/lib/graphql/generated/graphql.ts';
+import { makeToast } from '@/base/utils/Toast.ts';
+import { getErrorMessage } from '@/lib/HelperFunctions.ts';
+import { Mangas } from '@/features/manga/services/Mangas.ts';
+import { SpinnerImage } from '@/base/components/SpinnerImage.tsx';
+import { MANGA_STATUS_TO_TRANSLATION } from '@/features/manga/Manga.constants.ts';
+import type {
+    MangaArtistInfo,
+    MangaAuthorInfo,
+    MangaDescriptionInfo,
+    MangaGenreInfo,
+    MangaIdInfo,
+    MangaStatusInfo,
+    MangaThumbnailInfo,
+    MangaTitleInfo,
+} from '@/features/manga/Manga.types.ts';
+
+type EditableManga = MangaIdInfo &
+    MangaTitleInfo &
+    MangaStatusInfo &
+    MangaAuthorInfo &
+    MangaArtistInfo &
+    MangaDescriptionInfo &
+    MangaGenreInfo &
+    MangaThumbnailInfo;
+
+interface SearchResult {
+    externalId: string;
+    title: string;
+    author: string | null;
+    coverUrl: string | null;
+    year: number | null;
+    description: string | null;
+}
+
+const STATUS_OPTIONS = [
+    MangaStatus.Unknown,
+    MangaStatus.Ongoing,
+    MangaStatus.Completed,
+    MangaStatus.Licensed,
+    MangaStatus.PublishingFinished,
+    MangaStatus.Cancelled,
+    MangaStatus.OnHiatus,
+];
+
+const PROVIDERS = ['AniList', 'MangaUpdates'];
+
+const EditTab = ({ manga, onClose }: { manga: EditableManga; onClose: () => void }) => {
+    const { t } = useLingui();
+
+    const [title, setTitle] = useState(manga.title);
+    const [author, setAuthor] = useState(manga.author ?? '');
+    const [artist, setArtist] = useState(manga.artist ?? '');
+    const [description, setDescription] = useState(manga.description ?? '');
+    const [genre, setGenre] = useState<string[]>(manga.genre ?? []);
+    const [status, setStatus] = useState<MangaStatus>(manga.status);
+    const [coverFile, setCoverFile] = useState<File | null>(null);
+    const [coverPreview, setCoverPreview] = useState<string | null>(null);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const handleCoverSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) {
+            setCoverFile(file);
+            setCoverPreview(URL.createObjectURL(file));
+        }
+    };
+
+    const handleSubmit = async () => {
+        setIsSaving(true);
+        try {
+            const patch = {
+                title: title !== manga.title ? title : undefined,
+                author: author !== (manga.author ?? '') ? author : undefined,
+                artist: artist !== (manga.artist ?? '') ? artist : undefined,
+                description: description !== (manga.description ?? '') ? description : undefined,
+                genre: JSON.stringify(genre) !== JSON.stringify(manga.genre ?? []) ? genre : undefined,
+                status: status !== manga.status ? status : undefined,
+            };
+
+            const hasTextChanges = Object.values(patch).some((v) => v !== undefined);
+            if (hasTextChanges) {
+                await requestManager.updateMangaDetails(manga.id, patch).response;
+            }
+
+            if (coverFile) {
+                await requestManager.uploadMangaCover(manga.id, coverFile).response;
+            }
+
+            makeToast(t`Metadata updated successfully`, 'success');
+            onClose();
+        } catch (e) {
+            makeToast(t`Failed to update metadata`, 'error', getErrorMessage(e));
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    return (
+        <>
+            <DialogContent>
+                <Stack sx={{ gap: 2, mt: 1 }}>
+                    <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+                        <Box sx={{ position: 'relative', flexShrink: 0, width: 120 }}>
+                            <SpinnerImage
+                                src={coverPreview ?? Mangas.getThumbnailUrl(manga)}
+                                alt={manga.title}
+                                imgStyle={{
+                                    width: 120,
+                                    height: 180,
+                                    objectFit: 'cover',
+                                    borderRadius: 4,
+                                }}
+                            />
+                            <IconButton
+                                component="label"
+                                sx={{
+                                    position: 'absolute',
+                                    bottom: 4,
+                                    right: 4,
+                                    bgcolor: 'background.paper',
+                                    '&:hover': { bgcolor: 'action.hover' },
+                                }}
+                                size="small"
+                            >
+                                <PhotoCameraIcon fontSize="small" />
+                                <input type="file" hidden accept="image/*" onChange={handleCoverSelect} />
+                            </IconButton>
+                        </Box>
+                        <Stack sx={{ gap: 1, flex: 1 }}>
+                            <TextField
+                                label={t`Title`}
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
+                                fullWidth
+                                size="small"
+                            />
+                            <TextField
+                                label={t`Author`}
+                                value={author}
+                                onChange={(e) => setAuthor(e.target.value)}
+                                fullWidth
+                                size="small"
+                            />
+                            <TextField
+                                label={t`Artist`}
+                                value={artist}
+                                onChange={(e) => setArtist(e.target.value)}
+                                fullWidth
+                                size="small"
+                            />
+                        </Stack>
+                    </Box>
+                    <TextField
+                        select
+                        label={t`Status`}
+                        value={status}
+                        onChange={(e) => setStatus(e.target.value as MangaStatus)}
+                        fullWidth
+                        size="small"
+                    >
+                        {STATUS_OPTIONS.map((s) => (
+                            <MenuItem key={s} value={s}>
+                                {t(MANGA_STATUS_TO_TRANSLATION[s])}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+                    <Autocomplete
+                        multiple
+                        freeSolo
+                        options={[]}
+                        value={genre}
+                        onChange={(_, newValue) => setGenre(newValue)}
+                        renderTags={(value, getTagProps) =>
+                            value.map((option, index) => (
+                                <Chip
+                                    key={option}
+                                    variant="outlined"
+                                    label={option}
+                                    size="small"
+                                    {...getTagProps({ index })}
+                                />
+                            ))
+                        }
+                        renderInput={(params) => (
+                            <TextField {...params} label={t`Genres`} size="small" placeholder={t`Add genre`} />
+                        )}
+                    />
+                    <TextField
+                        label={t`Description`}
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        fullWidth
+                        multiline
+                        minRows={3}
+                        maxRows={6}
+                        size="small"
+                    />
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="primary">
+                    {t`Cancel`}
+                </Button>
+                <Button onClick={handleSubmit} color="primary" disabled={isSaving}>
+                    {isSaving ? t`Saving...` : t`Save`}
+                </Button>
+            </DialogActions>
+        </>
+    );
+};
+
+const MatchTab = ({ manga, onClose }: { manga: EditableManga; onClose: () => void }) => {
+    const { t } = useLingui();
+
+    const [provider, setProvider] = useState(PROVIDERS[0]);
+    const [searchQuery, setSearchQuery] = useState(manga.title);
+    const [results, setResults] = useState<SearchResult[]>([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [includeCover, setIncludeCover] = useState(true);
+    const [isApplying, setIsApplying] = useState(false);
+
+    const handleSearch = async () => {
+        if (!searchQuery.trim()) {
+            return;
+        }
+        setIsSearching(true);
+        setResults([]);
+        setSelectedId(null);
+        try {
+            const response = await requestManager.searchMetadataProvider(provider, searchQuery.trim()).response;
+            setResults(response.data?.searchMetadataProvider?.results ?? []);
+        } catch (e) {
+            makeToast(t`Search failed`, 'error', getErrorMessage(e));
+        } finally {
+            setIsSearching(false);
+        }
+    };
+
+    const handleApply = async () => {
+        if (!selectedId) {
+            return;
+        }
+        setIsApplying(true);
+        try {
+            await requestManager.applyMetadataMatch(manga.id, provider, selectedId, includeCover).response;
+            makeToast(t`Metadata applied successfully`, 'success');
+            onClose();
+        } catch (e) {
+            makeToast(t`Failed to apply metadata`, 'error', getErrorMessage(e));
+        } finally {
+            setIsApplying(false);
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            handleSearch();
+        }
+    };
+
+    return (
+        <>
+            <DialogContent>
+                <Stack sx={{ gap: 2, mt: 1 }}>
+                    <Box sx={{ display: 'flex', gap: 1 }}>
+                        <TextField
+                            select
+                            label={t`Provider`}
+                            value={provider}
+                            onChange={(e) => setProvider(e.target.value)}
+                            size="small"
+                            sx={{ minWidth: 150 }}
+                        >
+                            {PROVIDERS.map((p) => (
+                                <MenuItem key={p} value={p}>
+                                    {p}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                        <TextField
+                            label={t`Search`}
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            fullWidth
+                            size="small"
+                        />
+                        <IconButton
+                            onClick={handleSearch}
+                            disabled={isSearching || !searchQuery.trim()}
+                            color="primary"
+                        >
+                            {isSearching ? <CircularProgress size={24} /> : <SearchIcon />}
+                        </IconButton>
+                    </Box>
+
+                    {results.length > 0 && (
+                        <Stack sx={{ gap: 1, maxHeight: 400, overflowY: 'auto' }}>
+                            {results.map((result) => (
+                                <Card
+                                    key={result.externalId}
+                                    variant="outlined"
+                                    sx={{
+                                        border: selectedId === result.externalId ? 2 : 1,
+                                        borderColor: selectedId === result.externalId ? 'primary.main' : 'divider',
+                                    }}
+                                >
+                                    <CardActionArea onClick={() => setSelectedId(result.externalId)}>
+                                        <Box sx={{ display: 'flex', minHeight: 90 }}>
+                                            {result.coverUrl && (
+                                                <CardMedia
+                                                    component="img"
+                                                    image={result.coverUrl}
+                                                    alt={result.title}
+                                                    sx={{ width: 60, height: 90, objectFit: 'cover', flexShrink: 0 }}
+                                                />
+                                            )}
+                                            <CardContent
+                                                sx={{
+                                                    flex: 1,
+                                                    py: 1,
+                                                    '&:last-child': { pb: 1 },
+                                                    minWidth: 0,
+                                                    overflow: 'hidden',
+                                                }}
+                                            >
+                                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                                                    <Typography variant="subtitle2" noWrap sx={{ flex: 1 }}>
+                                                        {result.title}
+                                                    </Typography>
+                                                    {result.year && (
+                                                        <Typography variant="caption" color="text.secondary">
+                                                            {result.year}
+                                                        </Typography>
+                                                    )}
+                                                    {selectedId === result.externalId && (
+                                                        <CheckCircleIcon color="primary" fontSize="small" />
+                                                    )}
+                                                </Box>
+                                                {result.author && (
+                                                    <Typography variant="caption" color="text.secondary">
+                                                        {result.author}
+                                                    </Typography>
+                                                )}
+                                                {result.description && (
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                        component="p"
+                                                        sx={{
+                                                            display: '-webkit-box',
+                                                            WebkitLineClamp: 2,
+                                                            WebkitBoxOrient: 'vertical',
+                                                            overflow: 'hidden',
+                                                            mt: 0.5,
+                                                            wordBreak: 'break-word',
+                                                        }}
+                                                    >
+                                                        {result.description}
+                                                    </Typography>
+                                                )}
+                                            </CardContent>
+                                        </Box>
+                                    </CardActionArea>
+                                </Card>
+                            ))}
+                        </Stack>
+                    )}
+
+                    {!isSearching && results.length === 0 && searchQuery && (
+                        <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+                            {t`Search for manga to match metadata`}
+                        </Typography>
+                    )}
+                </Stack>
+            </DialogContent>
+            <DialogActions>
+                <FormControlLabel
+                    control={<Checkbox checked={includeCover} onChange={(e) => setIncludeCover(e.target.checked)} />}
+                    label={t`Include cover image`}
+                    sx={{ mr: 'auto', ml: 1 }}
+                />
+                <Button onClick={onClose} color="primary">
+                    {t`Cancel`}
+                </Button>
+                <Button onClick={handleApply} color="primary" disabled={!selectedId || isApplying}>
+                    {isApplying ? t`Applying...` : t`Apply`}
+                </Button>
+            </DialogActions>
+        </>
+    );
+};
+
+export const EditMangaMetadataDialog = ({ manga, onClose }: { manga: EditableManga; onClose: () => void }) => {
+    const { t } = useLingui();
+    const [tab, setTab] = useState(0);
+
+    return (
+        <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+            <Tabs value={tab} onChange={(_, v) => setTab(v)} variant="fullWidth">
+                <Tab label={t`Edit`} />
+                <Tab label={t`Match`} />
+            </Tabs>
+            {tab === 0 && <EditTab manga={manga} onClose={onClose} />}
+            {tab === 1 && <MatchTab manga={manga} onClose={onClose} />}
+        </Dialog>
+    );
+};

--- a/src/features/manga/components/details/MangaDetails.tsx
+++ b/src/features/manga/components/details/MangaDetails.tsx
@@ -6,11 +6,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import EditIcon from '@mui/icons-material/Edit';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { styled } from '@mui/material/styles';
 import type { ComponentProps, ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
@@ -51,6 +52,7 @@ import { Sources } from '@/features/source/services/Sources.ts';
 import type { SourceIdInfo } from '@/features/source/Source.types.ts';
 import { Thumbnail } from '@/features/manga/components/details/Thumbnail.tsx';
 import { DescriptionGenre } from '@/features/manga/components/details/DescriptionGenre.tsx';
+import { EditMangaMetadataDialog } from '@/features/manga/components/details/EditMangaMetadataDialog.tsx';
 import { SearchLink } from '@/features/manga/components/details/SearchLink.tsx';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
 import { IconBrowser } from '@/assets/icons/IconBrowser.tsx';
@@ -240,6 +242,8 @@ export const MangaDetails = ({
 
     const { updateLibraryState } = useManageMangaLibraryState(manga);
 
+    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+
     const copyTitle = async () => {
         try {
             await navigator.clipboard.writeText(manga.title);
@@ -294,9 +298,15 @@ export const MangaDetails = ({
                     </CustomButton>
                     <TrackMangaButton manga={manga} />
                     <OpenSourceButton url={manga.realUrl} />
+                    <CustomTooltip title={t`Edit Metadata`}>
+                        <CustomButtonIcon size="medium" variant="outlined" onClick={() => setIsEditDialogOpen(true)}>
+                            <EditIcon />
+                        </CustomButtonIcon>
+                    </CustomTooltip>
                 </MangaButtonsContainer>
             </TopContentWrapper>
             <DescriptionGenre manga={manga} mode={mode} />
+            {isEditDialogOpen && <EditMangaMetadataDialog manga={manga} onClose={() => setIsEditDialogOpen(false)} />}
         </DetailsWrapper>
     );
 };

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -289,6 +289,10 @@ msgstr "Add"
 msgid "Add bookmark"
 msgstr "Add bookmark"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Add genre"
+msgstr "Add genre"
+
 #: src/features/browse/screens/BrowseSettings.tsx
 msgid "Add repositories from which extensions can be installed"
 msgstr "Add repositories from which extensions can be installed"
@@ -358,6 +362,14 @@ msgstr "Also remove from {0}"
 msgid "Appearance"
 msgstr "Appearance"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Apply"
+msgstr "Apply"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Applying..."
+msgstr "Applying..."
+
 #: src/features/chapter/services/Chapters.ts
 #: src/features/manga/hooks/useManageMangaLibraryState.tsx
 #: src/features/manga/hooks/useManageMangaLibraryState.tsx
@@ -366,6 +378,7 @@ msgstr "Appearance"
 msgid "Are you sure?"
 msgstr "Are you sure?"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 #: src/features/manga/components/details/MangaDetails.tsx
 msgid "Artist"
 msgstr "Artist"
@@ -383,6 +396,7 @@ msgstr "Authentication"
 msgid "Authentication Mode"
 msgstr "Authentication Mode"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 #: src/features/manga/components/details/MangaDetails.tsx
 msgid "Author"
 msgstr "Author"
@@ -603,6 +617,8 @@ msgstr "Call timeout"
 #: src/features/category/components/CategoriesInclusionSetting.tsx
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/category/components/CreateOrEditCategoryDialog.tsx
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 #: src/features/migration/components/MigrateDialog.tsx
 #: src/features/reader/hotkeys/settings/components/RecordHotkey.tsx
 #: src/features/settings/components/globalUpdate/GlobalUpdateSettingsEntries.tsx
@@ -1223,6 +1239,10 @@ msgstr "Deleting theme \"{0}\"…"
 msgid "Descending"
 msgstr "Descending"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Description"
+msgstr "Description"
+
 #: src/features/chapter/components/cards/ChapterCard.tsx
 #: src/features/manga/components/MangaOptionButton.tsx
 msgid "Deselect"
@@ -1374,6 +1394,7 @@ msgstr "Edge"
 
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/category/components/CategorySettingsCard.tsx
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 #: src/features/theme/components/ThemePreview.tsx
 msgid "Edit"
 msgstr "Edit"
@@ -1391,6 +1412,10 @@ msgstr "Edit category"
 #: src/features/manga/components/MangaToolbarMenu.tsx
 msgid "Edit manga categories"
 msgstr "Edit manga categories"
+
+#: src/features/manga/components/details/MangaDetails.tsx
+msgid "Edit Metadata"
+msgstr "Edit Metadata"
 
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Edit theme"
@@ -1468,6 +1493,10 @@ msgstr "Extension installed"
 msgid "Extension repositories"
 msgstr "Extension repositories"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Failed to apply metadata"
+msgstr "Failed to apply metadata"
+
 #: src/features/settings/components/koreaderSync/KoreaderSyncSettings.tsx
 msgid "Failed to connect to KOReader Sync server."
 msgstr "Failed to connect to KOReader Sync server."
@@ -1514,6 +1543,10 @@ msgstr "Failed to disconnect from KOReader Sync server."
 #: src/features/tracker/screens/TrackingSettings.tsx
 msgid "Failed to save changes"
 msgstr "Failed to save changes"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Failed to update metadata"
+msgstr "Failed to update metadata"
 
 #: src/features/settings/Settings.constants.ts
 msgid ""
@@ -1627,6 +1660,10 @@ msgstr "Fourth to last read chapter"
 #: src/features/reader/settings/ReaderSettings.constants.tsx
 msgid "General"
 msgstr "General"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Genres"
+msgstr "Genres"
 
 #: src/features/settings/screens/About.tsx
 msgid "GitHub Server"
@@ -1789,6 +1826,10 @@ msgstr ""
 #: src/features/manga/components/MangaBadges.tsx
 msgid "In Library"
 msgstr "In Library"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Include cover image"
+msgstr "Include cover image"
 
 #: src/features/backup/screens/Backup.tsx
 #: src/features/category/components/CategoriesInclusionSetting.tsx
@@ -2165,6 +2206,10 @@ msgstr "Mark selected as read"
 msgid "Mark selected as unread"
 msgstr "Mark selected as unread"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Match"
+msgstr "Match"
+
 #: src/features/settings/screens/ServerSettings.tsx
 msgid "Maximum log file size"
 msgstr "Maximum log file size"
@@ -2180,6 +2225,14 @@ msgstr "Medium"
 #: src/features/reader/tap-zones/ReaderTapZone.constants.ts
 msgid "Menu"
 msgstr "Menu"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Metadata applied successfully"
+msgstr "Metadata applied successfully"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Metadata updated successfully"
+msgstr "Metadata updated successfully"
 
 #: src/features/browse/screens/Browse.tsx
 #: src/features/manga/components/MangaToolbarMenu.tsx
@@ -2560,6 +2613,10 @@ msgstr "Progress bar style"
 msgid "Prompt"
 msgstr "Prompt"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Provider"
+msgstr "Provider"
+
 #: src/features/manga/Manga.constants.ts
 msgid "Publishing finished"
 msgstr "Publishing finished"
@@ -2746,6 +2803,7 @@ msgstr "Right to left"
 msgid "Rosegold"
 msgstr "Rosegold"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 #: src/features/settings/screens/ImageProcessingSetting.tsx
 #: src/features/theme/components/CreateThemeDialog.tsx
 #: src/features/theme/components/CreateThemeDialog.tsx
@@ -2778,6 +2836,10 @@ msgstr "Saved theme changes"
 msgid "Saving theme changes…"
 msgstr "Saving theme changes…"
 
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Saving..."
+msgstr "Saving..."
+
 #: src/features/reader/overlay/navigation/desktop/quick-settings/components/ReaderNavBarDesktopPageScale.tsx
 #: src/features/reader/settings/layout/components/ReaderSettingPageScaleMode.tsx
 msgid "Scale type"
@@ -2809,8 +2871,13 @@ msgid "Scroll forward"
 msgstr "Scroll forward"
 
 #: src/base/components/AppbarSearch.tsx
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 msgid "Search"
 msgstr "Search"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Search failed"
+msgstr "Search failed"
 
 #: src/features/library/screens/Library.tsx
 msgid "Search for \"{query}\" globally"
@@ -2823,6 +2890,10 @@ msgid ""
 msgstr ""
 "Search for a ID via \"id:<ID>\" (e.g. \"id:13\")\n"
 "Limit search to your lists via \"my:<Title>\" (e.g. \"my:One Piece\")"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Search for manga to match metadata"
+msgstr "Search for manga to match metadata"
 
 #: src/features/settings/components/images/Processing.tsx
 msgid "Search parameters"
@@ -3154,6 +3225,7 @@ msgid "Static navigation"
 msgstr "Static navigation"
 
 #: src/features/library/components/LibraryOptionsPanel.tsx
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
 #: src/features/manga/components/details/MangaDetails.tsx
 #: src/features/tracker/components/cards/TrackerActiveCard.tsx
 #: src/features/tracker/components/cards/TrackerMangaCard.tsx
@@ -3332,6 +3404,10 @@ msgstr "This will remove the tracking locally."
 #: src/features/reader/settings/behaviour/components/ReaderSettingScrollAmount.tsx
 msgid "Tiny"
 msgstr "Tiny"
+
+#: src/features/manga/components/details/EditMangaMetadataDialog.tsx
+msgid "Title"
+msgstr "Title"
 
 #: src/base/utils/DateHelper.ts
 msgid "Today"

--- a/src/lib/graphql/manga/MangaMutation.ts
+++ b/src/lib/graphql/manga/MangaMutation.ts
@@ -171,6 +171,30 @@ export const UPDATE_MANGAS_CATEGORIES = gql`
     }
 `;
 
+export const UPDATE_MANGA_DETAILS = gql`
+    ${MANGA_SCREEN_FIELDS}
+
+    mutation UPDATE_MANGA_DETAILS($input: UpdateMangaDetailsInput!) {
+        updateMangaDetails(input: $input) {
+            manga {
+                ...MANGA_SCREEN_FIELDS
+            }
+        }
+    }
+`;
+
+export const UPLOAD_MANGA_COVER = gql`
+    ${MANGA_SCREEN_FIELDS}
+
+    mutation UPLOAD_MANGA_COVER($id: Int!, $cover: Upload!) {
+        uploadMangaCover(input: { id: $id, cover: $cover }) {
+            manga {
+                ...MANGA_SCREEN_FIELDS
+            }
+        }
+    }
+`;
+
 export const UPDATE_MANGA_METADATA = gql`
     ${MANGA_META_FIELDS}
 

--- a/src/lib/graphql/manga/MetadataMutation.ts
+++ b/src/lib/graphql/manga/MetadataMutation.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import gql from 'graphql-tag';
+import { MANGA_SCREEN_FIELDS } from '@/lib/graphql/manga/MangaFragments.ts';
+
+export const SEARCH_METADATA_PROVIDER = gql`
+    mutation SEARCH_METADATA_PROVIDER($provider: String!, $query: String!, $author: String) {
+        searchMetadataProvider(input: { provider: $provider, query: $query, author: $author }) {
+            results {
+                externalId
+                title
+                author
+                coverUrl
+                year
+                description
+            }
+        }
+    }
+`;
+
+export const APPLY_METADATA_MATCH = gql`
+    ${MANGA_SCREEN_FIELDS}
+
+    mutation APPLY_METADATA_MATCH($mangaId: Int!, $provider: String!, $externalId: String!, $includeCover: Boolean!) {
+        applyMetadataMatch(
+            input: { mangaId: $mangaId, provider: $provider, externalId: $externalId, includeCover: $includeCover }
+        ) {
+            manga {
+                ...MANGA_SCREEN_FIELDS
+            }
+        }
+    }
+`;

--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -212,6 +212,7 @@ import type {
     DeleteChapterMetasInput,
     SetCategoryMetasInput,
     DeleteCategoryMetasInput,
+    MangaStatus,
 } from '@/lib/graphql/generated/graphql.ts';
 import {
     CategoryOrderBy,
@@ -242,10 +243,13 @@ import {
     GET_MANGA_TO_MIGRATE_TO_FETCH,
     UPDATE_MANGA,
     UPDATE_MANGA_CATEGORIES,
+    UPDATE_MANGA_DETAILS,
     UPDATE_MANGA_METADATA,
     UPDATE_MANGAS,
     UPDATE_MANGAS_CATEGORIES,
+    UPLOAD_MANGA_COVER,
 } from '@/lib/graphql/manga/MangaMutation.ts';
+import { SEARCH_METADATA_PROVIDER, APPLY_METADATA_MATCH } from '@/lib/graphql/manga/MetadataMutation.ts';
 import {
     GET_MANGA_TO_MIGRATE,
     GET_MANGA_TRACK_RECORDS,
@@ -2327,6 +2331,46 @@ export class RequestManager {
         });
 
         return result;
+    }
+
+    public updateMangaDetails(
+        id: number,
+        patch: {
+            title?: string;
+            author?: string;
+            artist?: string;
+            description?: string;
+            genre?: string[];
+            status?: MangaStatus;
+        },
+    ): AbortableApolloMutationResponse<any> {
+        return this.doRequest(GQLMethod.MUTATION, UPDATE_MANGA_DETAILS, { input: { id, patch } });
+    }
+
+    public uploadMangaCover(id: number, cover: File): AbortableApolloMutationResponse<any> {
+        return this.doRequest(GQLMethod.MUTATION, UPLOAD_MANGA_COVER, { id, cover });
+    }
+
+    public searchMetadataProvider(
+        provider: string,
+        query: string,
+        author?: string,
+    ): AbortableApolloMutationResponse<any> {
+        return this.doRequest(GQLMethod.MUTATION, SEARCH_METADATA_PROVIDER, { provider, query, author });
+    }
+
+    public applyMetadataMatch(
+        mangaId: number,
+        provider: string,
+        externalId: string,
+        includeCover: boolean,
+    ): AbortableApolloMutationResponse<any> {
+        return this.doRequest(GQLMethod.MUTATION, APPLY_METADATA_MATCH, {
+            mangaId,
+            provider,
+            externalId,
+            includeCover,
+        });
     }
 
     public updateMangas(


### PR DESCRIPTION
## Summary

- Adds an **Edit Metadata** button (pencil icon) to the manga details page
- Opens a tabbed dialog with two tabs:
  - **Edit** — manual editing of title, author, artist, description, genres, status, and custom cover image upload
  - **Match** — search AniList or MangaUpdates by title, select a result, optionally include cover image, and apply metadata from the provider

## Dependencies

Requires server-side mutations from Suwayomi/Suwayomi-Server#1945:
- `updateMangaDetails` — edit manga metadata
- `uploadMangaCover` — upload custom cover image
- `searchMetadataProvider` — search external providers
- `applyMetadataMatch` — apply metadata from a matched result

## Files Changed

| File | Change |
|------|--------|
| `src/features/manga/components/details/EditMangaMetadataDialog.tsx` | New — tabbed dialog with Edit and Match tabs |
| `src/features/manga/components/details/MangaDetails.tsx` | Modified — added edit button |
| `src/lib/graphql/manga/MangaMutation.ts` | Modified — added `UPDATE_MANGA_DETAILS` and `UPLOAD_MANGA_COVER` mutations |
| `src/lib/graphql/manga/MetadataMutation.ts` | New — `SEARCH_METADATA_PROVIDER` and `APPLY_METADATA_MATCH` mutations |
| `src/lib/requests/RequestManager.ts` | Modified — added 4 new methods for the mutations |

## Test plan

- [x] Manual test: Edit tab — update title, author, artist, description, genres, status
- [x] Manual test: Edit tab — upload custom cover image
- [x] Manual test: Match tab — search AniList and MangaUpdates
- [x] Manual test: Match tab — apply metadata with cover from provider
- [x] Build: `yarn build` passes
- [x] Lint: pre-commit hooks pass (oxlint + oxfmt)
- [x] No changes to existing mutations or components