### PR TITLE
Add personal notes to manga detail page

### DIFF
--- a/src/modules/manga/Manga.types.ts
+++ b/src/modules/manga/Manga.types.ts
@@ -16,6 +16,7 @@ import {
     MangaReaderFieldsFragment,
     MangaType as MangaTypeGql,
     Maybe,
+    MetaType,
     SourceType,
     TrackRecordType,
 } from '@/lib/graphql/generated/graphql.ts';
@@ -49,6 +50,7 @@ export type MangaAuthorInfo = Pick<MangaTypeGql, 'author'>;
 export type MangaTitleInfo = Pick<MangaTypeGql, 'title'>;
 export type MangaDescriptionInfo = Pick<MangaTypeGql, 'description'>;
 export type MangaStatusInfo = Pick<MangaTypeGql, 'status'>;
+export type MangaMetaInfo = { meta?: Pick<MetaType, 'key' | 'value'>[] };
 
 export type MigrateMode = 'copy' | 'migrate';
 
@@ -74,7 +76,9 @@ export type SpecificMangaCardProps = Omit<MangaCardProps, 'manga'> &
         mangaBadges: JSX.Element;
     };
 
-export type MangaMetadata = ChapterListOptions;
+export type MangaMetadata = ChapterListOptions & {
+    notes: string;
+};
 
 export type MangaMetadataKeys = keyof MangaMetadata;
 

--- a/src/modules/manga/components/details/MangaDetails.tsx
+++ b/src/modules/manga/components/details/MangaDetails.tsx
@@ -38,6 +38,7 @@ import {
     MangaIdInfo,
     MangaInLibraryInfo,
     MangaLocationState,
+    MangaMetaInfo,
     MangaSourceIdInfo,
     MangaStatusInfo,
     MangaThumbnailInfo,
@@ -50,6 +51,7 @@ import { Sources } from '@/modules/source/services/Sources.ts';
 import { SourceIdInfo } from '@/modules/source/Source.types.ts';
 import { Thumbnail } from '@/modules/manga/components/details/Thumbnail.tsx';
 import { DescriptionGenre } from '@/modules/manga/components/details/DescriptionGenre.tsx';
+import { MangaNotes } from '@/modules/manga/components/details/MangaNotes.tsx';
 import { SearchLink } from '@/modules/manga/components/details/SearchLink.tsx';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
 import { IconBrowser } from '@/assets/icons/IconBrowser.tsx';
@@ -210,7 +212,8 @@ export const MangaDetails = ({
         MangaGenreInfo &
         MangaThumbnailInfo &
         MangaSourceIdInfo &
-        MangaTrackRecordInfo & {
+        MangaTrackRecordInfo &
+        MangaMetaInfo & {
             source?: Pick<SourceType, 'id' | 'displayName'> | null;
         };
     mode: MangaLocationState['mode'];
@@ -290,6 +293,7 @@ export const MangaDetails = ({
                     </MangaButtonsContainer>
                 </TopContentWrapper>
                 <DescriptionGenre manga={manga} mode={mode} />
+            <MangaNotes manga={manga} />
             </DetailsWrapper>
             {CategorySelectComponent}
         </>

--- a/src/modules/manga/components/details/MangaNotes.tsx
+++ b/src/modules/manga/components/details/MangaNotes.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useState } from 'react';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import EditIcon from '@mui/icons-material/Edit';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import { useTranslation } from 'react-i18next';
+import { MangaIdInfo, MangaMetaInfo } from '@/modules/manga/Manga.types.ts';
+import { useGetMangaMetadata, createUpdateMangaMetadata } from '@/modules/manga/services/MangaMetadata.ts';
+
+export const MangaNotes = ({ manga }: { manga: MangaIdInfo & MangaMetaInfo }) => {
+    const { t } = useTranslation();
+    const { notes } = useGetMangaMetadata(manga);
+    const [isEditing, setIsEditing] = useState(false);
+    const [draft, setDraft] = useState('');
+
+    const handleOpen = () => {
+        setDraft(notes);
+        setIsEditing(true);
+    };
+
+    const handleSave = () => {
+        const updateMetadata = createUpdateMangaMetadata(manga);
+        updateMetadata('notes', draft);
+        setIsEditing(false);
+    };
+
+    return (
+        <>
+            <Stack
+                sx={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 0.5,
+                }}
+            >
+                <Typography variant="subtitle2" color="text.secondary">
+                    {t('manga.label.notes', 'Notes')}
+                </Typography>
+                <IconButton size="small" onClick={handleOpen} color="inherit">
+                    <EditIcon fontSize="small" />
+                </IconButton>
+            </Stack>
+            {notes && (
+                <Typography
+                    sx={{
+                        whiteSpace: 'pre-line',
+                        fontSize: '0.875rem',
+                        color: 'text.secondary',
+                    }}
+                >
+                    {notes}
+                </Typography>
+            )}
+            <Dialog open={isEditing} onClose={() => setIsEditing(false)} fullWidth maxWidth="sm">
+                <DialogTitle>{t('manga.label.edit_notes', 'Edit Notes')}</DialogTitle>
+                <DialogContent>
+                    <TextField
+                        autoFocus
+                        multiline
+                        minRows={3}
+                        maxRows={10}
+                        fullWidth
+                        margin="dense"
+                        placeholder={t('manga.label.notes_placeholder', 'Add your notes here...')}
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setIsEditing(false)}>{t('global.button.cancel', 'Cancel')}</Button>
+                    <Button onClick={handleSave} variant="contained">
+                        {t('global.button.save', 'Save')}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};

--- a/src/modules/manga/services/MangaMetadata.ts
+++ b/src/modules/manga/services/MangaMetadata.ts
@@ -22,6 +22,7 @@ import { defaultPromiseErrorHandler } from '@/lib/DefaultPromiseErrorHandler.ts'
 
 const DEFAULT_MANGA_METADATA: MangaMetadata = {
     ...DEFAULT_CHAPTER_OPTIONS,
+    notes: '',
 };
 
 const convertAppMetadataToGqlMetadata = (

--- a/src/modules/metadata/Metadata.constants.ts
+++ b/src/modules/metadata/Metadata.constants.ts
@@ -375,6 +375,9 @@ export const APP_METADATA: Record<
     excludedScanlators: {
         convert: convertToObject<string[]>,
     },
+    notes: {
+        convert: convertToString,
+    },
 } as const;
 
 export const VALID_APP_METADATA_KEYS = Object.keys(APP_METADATA);
@@ -466,6 +469,7 @@ export const GLOBAL_METADATA_KEYS: AppMetadataKeys[] = [
     'unread',
     'showChapterNumber',
     'excludedScanlators',
+    'notes',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds a **Notes** field to the manga detail page, allowing users to write and save personal notes for each manga.

### How it works
- Uses the existing `MangaMetaTable` key-value API (`webUI_notes` key)
- No backend changes needed — the `meta` field is already fetched in `GET_MANGA_SCREEN`
- Notes are global (same across devices), registered in `GLOBAL_METADATA_KEYS`

### Changes (5 files, +107/-2 lines)
- **`Metadata.constants.ts`** — Register `notes` in `APP_METADATA` (string converter) and `GLOBAL_METADATA_KEYS`
- **`MangaMetadata.ts`** — Add `notes: ''` to `DEFAULT_MANGA_METADATA`
- **`Manga.types.ts`** — Add `MangaMetaInfo` type, extend `MangaMetadata` with `notes: string`
- **`MangaNotes.tsx`** *(new)* — View/edit component with dialog (multiline TextField, Save/Cancel)
- **`MangaDetails.tsx`** — Wire `<MangaNotes>` below `<DescriptionGenre>`

### UI
The Notes section appears below the description/genre area with a pencil edit icon. Clicking it opens a dialog to add/edit notes.

### Compatibility
Based on `v20250801.01` (compatible with server v2.1.x / r1856+).
