### PR TITLE
feat(manga): add Related button with AniList/MAL relations & recommendations

### DIFF
--- a/src/features/browse/Browse.types.ts
+++ b/src/features/browse/Browse.types.ts
@@ -14,6 +14,7 @@ export type MetadataBrowseSettings = {
     showNsfw: boolean;
     lastUsedSourceId: SourceIdInfo['id'] | null;
     shouldShowOnlySourcesWithResults: boolean;
+    showRelatedForEachManga: boolean;
 };
 
 export enum BrowseTab {

--- a/src/features/browse/screens/BrowseSettings.tsx
+++ b/src/features/browse/screens/BrowseSettings.tsx
@@ -53,7 +53,7 @@ export const BrowseSettings = () => {
     };
 
     const {
-        settings: { hideLibraryEntries, showNsfw },
+        settings: { hideLibraryEntries, showNsfw, showRelatedForEachManga },
     } = useMetadataServerSettings();
     const updateMetadataServerSettings = createUpdateMetadataServerSettings<keyof MetadataBrowseSettings>((e) =>
         makeToast(t`Failed to save changes`, 'error', getErrorMessage(e)),
@@ -145,6 +145,27 @@ export const BrowseSettings = () => {
                     }
                     handleChange={(path) => updateSetting('localSourcePath', path)}
                 />
+            </List>
+            <List
+                subheader={
+                    <ListSubheader component="div" id="browse-settings-manga">
+                        {t`Manga`}
+                    </ListSubheader>
+                }
+            >
+                <ListItem>
+                    <ListItemText
+                        primary={t`Show related for each manga`}
+                        secondary={t`Currently supported for: AniList, MyAnimeList`}
+                    />
+                    <Switch
+                        edge="end"
+                        checked={showRelatedForEachManga}
+                        onChange={() =>
+                            updateMetadataServerSettings('showRelatedForEachManga', !showRelatedForEachManga)
+                        }
+                    />
+                </ListItem>
             </List>
             <List
                 subheader={

--- a/src/features/manga/components/RelatedMangaButton.tsx
+++ b/src/features/manga/components/RelatedMangaButton.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import RecommendIcon from '@mui/icons-material/Recommend';
+import PopupState, { bindDialog, bindTrigger } from 'material-ui-popup-state';
+import Dialog from '@mui/material/Dialog';
+import { useLingui } from '@lingui/react/macro';
+import { FlexWrapButton } from '@/base/components/buttons/FlexWrapButton.tsx';
+import { MangaRelated } from '@/features/tracker/components/MangaRelated.tsx';
+import { useMetadataServerSettings } from '@/features/settings/services/ServerSettingsMetadata.ts';
+import type { MangaIdInfo } from '@/features/manga/Manga.types.ts';
+import { MediaQuery } from '@/base/utils/MediaQuery.tsx';
+
+export const RelatedMangaButton = ({ manga }: { manga: MangaIdInfo }) => {
+    const { t } = useLingui();
+    const isMobileWidth = MediaQuery.useIsMobileWidth();
+
+    const {
+        settings: { showRelatedForEachManga },
+    } = useMetadataServerSettings();
+
+    if (!showRelatedForEachManga) {
+        return null;
+    }
+
+    return (
+        <PopupState variant="dialog" popupId="manga-related-modal">
+            {(popupState) => (
+                <>
+                    <FlexWrapButton
+                        {...bindTrigger(popupState)}
+                        size={isMobileWidth ? 'small' : 'medium'}
+                        variant="outlined"
+                    >
+                        <RecommendIcon />
+                        {t`Related`}
+                    </FlexWrapButton>
+                    {popupState.isOpen && (
+                        <Dialog {...bindDialog(popupState)} maxWidth="md" fullWidth scroll="paper">
+                            <MangaRelated manga={manga} />
+                        </Dialog>
+                    )}
+                </>
+            )}
+        </PopupState>
+    );
+};

--- a/src/features/manga/components/details/MangaDetails.tsx
+++ b/src/features/manga/components/details/MangaDetails.tsx
@@ -25,6 +25,7 @@ import { Mangas } from '@/features/manga/services/Mangas.ts';
 import { SpinnerImage } from '@/base/components/SpinnerImage.tsx';
 import { FlexWrapButton } from '@/base/components/buttons/FlexWrapButton.tsx';
 import { TrackMangaButton } from '@/features/manga/components/TrackMangaButton.tsx';
+import { RelatedMangaButton } from '@/features/manga/components/RelatedMangaButton.tsx';
 import { useManageMangaLibraryState } from '@/features/manga/hooks/useManageMangaLibraryState.tsx';
 import { Metadata as BaseMetadata } from '@/base/components/texts/Metadata.tsx';
 import { defaultPromiseErrorHandler } from '@/lib/DefaultPromiseErrorHandler.ts';
@@ -293,6 +294,7 @@ export const MangaDetails = ({
                         {manga.inLibrary ? t`In Library` : t`Add To Library`}
                     </FlexWrapButton>
                     <TrackMangaButton manga={manga} />
+                    <RelatedMangaButton manga={manga} />
                     <OpenSourceButton url={manga.realUrl} />
                 </MangaButtonsContainer>
             </TopContentWrapper>

--- a/src/features/metadata/Metadata.constants.ts
+++ b/src/features/metadata/Metadata.constants.ts
@@ -388,6 +388,9 @@ export const APP_METADATA: Record<
     shouldShowOnlySourcesWithResults: {
         convert: convertToBoolean,
     },
+    showRelatedForEachManga: {
+        convert: convertToBoolean,
+    },
     excludedScanlators: {
         convert: convertToObject<string[]>,
     },
@@ -460,6 +463,7 @@ export const GLOBAL_METADATA_KEYS: AppMetadataKeys[] = [
     'showNsfw',
     'lastUsedSourceId',
     'shouldShowOnlySourcesWithResults',
+    'showRelatedForEachManga',
 
     // history
     'hideHistory',

--- a/src/features/settings/Settings.constants.ts
+++ b/src/features/settings/Settings.constants.ts
@@ -72,6 +72,7 @@ export const SERVER_SETTINGS_METADATA_DEFAULT: MetadataServerSettings = {
     showNsfw: true,
     lastUsedSourceId: null,
     shouldShowOnlySourcesWithResults: true,
+    showRelatedForEachManga: true,
 
     // history
     hideHistory: false,

--- a/src/features/tracker/components/MangaRelated.tsx
+++ b/src/features/tracker/components/MangaRelated.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import { useLingui } from '@lingui/react/macro';
+import type { MessageDescriptor } from '@lingui/core';
+import { msg } from '@lingui/core/macro';
+import { i18n } from '@/i18n';
+import { requestManager } from '@/lib/requests/RequestManager.ts';
+import { LoadingPlaceholder } from '@/base/components/feedback/LoadingPlaceholder.tsx';
+import { EmptyView } from '@/base/components/feedback/EmptyView.tsx';
+import { AvatarSpinner } from '@/base/components/AvatarSpinner.tsx';
+import { SpinnerImage } from '@/base/components/SpinnerImage.tsx';
+import { defaultPromiseErrorHandler } from '@/lib/DefaultPromiseErrorHandler.ts';
+import { getErrorMessage } from '@/lib/HelperFunctions.ts';
+import type {
+    GetMangaRelatedQuery,
+    GetTrackersSettingsQuery,
+    RelatedMangaFieldsFragment,
+} from '@/lib/graphql/generated/graphql.ts';
+import { GET_TRACKERS_SETTINGS } from '@/lib/graphql/tracker/TrackerQuery.ts';
+import type { MangaIdInfo } from '@/features/manga/Manga.types.ts';
+import { STABLE_EMPTY_ARRAY } from '@/base/Base.constants.ts';
+
+type RelatedManga = GetMangaRelatedQuery['mangaRelated'];
+
+type SectionDefinition = {
+    title: MessageDescriptor;
+    trackerName: string;
+    items: (related: RelatedManga) => RelatedMangaFieldsFragment[];
+};
+
+// The tracker names must match the names provided by the server (see TrackerManager on the server).
+const ANILIST_NAME = 'AniList';
+const MYANIMELIST_NAME = 'MyAnimeList';
+
+const SECTIONS: SectionDefinition[] = [
+    {
+        title: msg`AniList - Relations`,
+        trackerName: ANILIST_NAME,
+        items: (related) => related.anilistRelations,
+    },
+    {
+        title: msg`AniList - Recommendations`,
+        trackerName: ANILIST_NAME,
+        items: (related) => related.anilistRecommendations,
+    },
+    {
+        title: msg`MyAnimeList - Related Entries`,
+        trackerName: MYANIMELIST_NAME,
+        items: (related) => related.myanimelistRelations,
+    },
+    {
+        title: msg`MyAnimeList - Recommendations`,
+        trackerName: MYANIMELIST_NAME,
+        items: (related) => related.myanimelistRecommendations,
+    },
+];
+
+const RelatedMangaCard = ({ item }: { item: RelatedMangaFieldsFragment }) => (
+    <Link
+        href={item.trackingUrl}
+        target="_blank"
+        rel="noreferrer"
+        underline="none"
+        color="inherit"
+        sx={{ flexShrink: 0, width: '120px' }}
+    >
+        <Box sx={{ width: '120px', aspectRatio: '225 / 350', borderRadius: 1, overflow: 'hidden' }}>
+            <SpinnerImage
+                src={item.coverUrl}
+                alt={item.title}
+                useFetchApi={false}
+                imgStyle={{ objectFit: 'cover', width: '100%', height: '100%' }}
+            />
+        </Box>
+        {item.relationType && (
+            <Typography variant="caption" color="primary" sx={{ display: 'block', mt: 0.5 }}>
+                {item.relationType}
+            </Typography>
+        )}
+        <Typography
+            variant="body2"
+            sx={{
+                mt: item.relationType ? 0 : 0.5,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+            }}
+        >
+            {item.title}
+        </Typography>
+    </Link>
+);
+
+const RelatedSection = ({
+    title,
+    iconUrl,
+    items,
+}: {
+    title: string;
+    iconUrl?: string;
+    items: RelatedMangaFieldsFragment[];
+}) => {
+    const { t } = useLingui();
+
+    return (
+        <Stack sx={{ gap: 1 }}>
+            <Stack direction="row" sx={{ alignItems: 'center', gap: 1 }}>
+                {iconUrl && (
+                    <AvatarSpinner
+                        alt={title}
+                        iconUrl={iconUrl}
+                        slots={{
+                            avatarProps: { variant: 'rounded', sx: { width: 24, height: 24 } },
+                            spinnerImageProps: { ignoreQueue: true },
+                        }}
+                    />
+                )}
+                <Typography variant="h6">{title}</Typography>
+            </Stack>
+            {items.length ? (
+                <Stack
+                    direction="row"
+                    sx={{
+                        gap: 1.5,
+                        overflowX: 'auto',
+                        pb: 1,
+                        alignItems: 'flex-start',
+                    }}
+                >
+                    {items.map((item) => (
+                        <RelatedMangaCard key={item.remoteId} item={item} />
+                    ))}
+                </Stack>
+            ) : (
+                <Typography color="textSecondary" variant="body2">
+                    {t`Nothing found`}
+                </Typography>
+            )}
+        </Stack>
+    );
+};
+
+export const MangaRelated = ({ manga }: { manga: MangaIdInfo }) => {
+    const { t } = useLingui();
+
+    const relatedList = requestManager.useGetMangaRelated(manga.id);
+    const trackerList = requestManager.useGetTrackerList<GetTrackersSettingsQuery>(GET_TRACKERS_SETTINGS);
+
+    const trackers = trackerList.data?.trackers.nodes ?? STABLE_EMPTY_ARRAY;
+    const getIconUrl = (trackerName: string): string | undefined => {
+        const tracker = trackers.find(({ name }) => name === trackerName);
+        return tracker ? requestManager.getValidImgUrlFor(tracker.icon) : undefined;
+    };
+
+    const loading = relatedList.loading || trackerList.loading;
+    const error = relatedList.error ?? trackerList.error;
+
+    if (error) {
+        return (
+            <>
+                <DialogTitle>{t`Related`}</DialogTitle>
+                <DialogContent>
+                    <EmptyView
+                        message={t`Unable to load data`}
+                        messageExtra={getErrorMessage(error)}
+                        retry={() => {
+                            relatedList.refetch().catch(defaultPromiseErrorHandler('MangaRelated::refetch: related'));
+                            trackerList.refetch().catch(defaultPromiseErrorHandler('MangaRelated::refetch: trackers'));
+                        }}
+                    />
+                </DialogContent>
+            </>
+        );
+    }
+
+    if (loading || !relatedList.data) {
+        return (
+            <>
+                <DialogTitle>{t`Related`}</DialogTitle>
+                <DialogContent>
+                    <LoadingPlaceholder />
+                </DialogContent>
+            </>
+        );
+    }
+
+    const related = relatedList.data.mangaRelated;
+
+    return (
+        <>
+            <DialogTitle>{t`Related`}</DialogTitle>
+            <DialogContent dividers>
+                <Stack sx={{ gap: 3 }}>
+                    {SECTIONS.map((section) => (
+                        <RelatedSection
+                            key={i18n._(section.title)}
+                            title={i18n._(section.title)}
+                            iconUrl={getIconUrl(section.trackerName)}
+                            items={section.items(related)}
+                        />
+                    ))}
+                </Stack>
+            </DialogContent>
+        </>
+    );
+};

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -437,6 +437,14 @@ msgstr "Alpha"
 msgid "Also remove from {0}"
 msgstr "Also remove from {0}"
 
+#: src/features/tracker/components/MangaRelated.tsx
+msgid "AniList - Recommendations"
+msgstr "AniList - Recommendations"
+
+#: src/features/tracker/components/MangaRelated.tsx
+msgid "AniList - Relations"
+msgstr "AniList - Relations"
+
 #: src/features/settings/screens/Appearance.tsx
 #: src/features/settings/screens/Settings.tsx
 msgid "Appearance"
@@ -1194,6 +1202,10 @@ msgstr "Current:"
 #: src/features/tracker/Tracker.constants.ts
 msgid "Currently publishing"
 msgstr "Currently publishing"
+
+#: src/features/browse/screens/BrowseSettings.tsx
+msgid "Currently supported for: AniList, MyAnimeList"
+msgstr "Currently supported for: AniList, MyAnimeList"
 
 #: src/features/settings/Settings.constants.ts
 msgid "Custom"
@@ -2274,6 +2286,7 @@ msgstr ""
 "UI specific settings that are stored on the server are per device.\n"
 "This makes it possible to have e.g. different settings on a desktop and a smartphone"
 
+#: src/features/browse/screens/BrowseSettings.tsx
 #: src/features/manga/Manga.constants.ts
 #: src/features/manga/screens/Manga.tsx
 #: src/features/reader/settings/behaviour/components/ReaderSettingExitMode.tsx
@@ -2467,6 +2480,14 @@ msgstr "Multi"
 msgid "Multiply"
 msgstr "Multiply"
 
+#: src/features/tracker/components/MangaRelated.tsx
+msgid "MyAnimeList - Recommendations"
+msgstr "MyAnimeList - Recommendations"
+
+#: src/features/tracker/components/MangaRelated.tsx
+msgid "MyAnimeList - Related Entries"
+msgstr "MyAnimeList - Related Entries"
+
 #: src/features/settings/components/images/KeyValueItem.tsx
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Name"
@@ -2559,6 +2580,10 @@ msgstr "Not yet published"
 #: src/features/tracker/Tracker.constants.ts
 msgid "Not yet released"
 msgstr "Not yet released"
+
+#: src/features/tracker/components/MangaRelated.tsx
+msgid "Nothing found"
+msgstr "Nothing found"
 
 #: src/features/tracker/Tracker.constants.ts
 msgid "Novel"
@@ -2866,6 +2891,11 @@ msgstr "Red"
 #: src/features/app-updates/components/WebUIUpdateChecker.tsx
 msgid "Refresh"
 msgstr "Refresh"
+
+#: src/features/manga/components/RelatedMangaButton.tsx
+#: src/features/tracker/components/MangaRelated.tsx
+msgid "Related"
+msgstr "Related"
 
 #: src/features/tracker/Tracker.constants.ts
 msgid "Releasing"
@@ -3277,6 +3307,10 @@ msgstr "Show page number"
 #: src/features/reader/settings/behaviour/ReaderBehaviourSettings.tsx
 msgid "Show reading mode"
 msgstr "Show reading mode"
+
+#: src/features/browse/screens/BrowseSettings.tsx
+msgid "Show related for each manga"
+msgstr "Show related for each manga"
 
 #: src/features/reader/settings/behaviour/ReaderBehaviourSettings.tsx
 msgid "Show tap zones overlay"
@@ -3754,6 +3788,7 @@ msgstr "UI Login"
 #: src/features/source/configuration/screens/SourceConfigure.tsx
 #: src/features/theme/components/CreateThemeDialog.tsx
 #: src/features/theme/components/ThemeList.tsx
+#: src/features/tracker/components/MangaRelated.tsx
 #: src/features/tracker/components/TrackerSearch.tsx
 #: src/features/tracker/components/TrackManga.tsx
 #: src/features/tracker/screens/TrackingSettings.tsx

--- a/src/lib/graphql/generated/graphql.ts
+++ b/src/lib/graphql/generated/graphql.ts
@@ -4052,6 +4052,58 @@ export type TrackerSearchQuery = {
     };
 };
 
+export type RelatedMangaFieldsFragment = {
+    __typename: 'TrackRelatedMangaType';
+    remoteId: string;
+    title: string;
+    coverUrl: string;
+    trackingUrl: string;
+    relationType: string | null;
+};
+
+export type GetMangaRelatedQueryVariables = Exact<{
+    mangaId: number;
+}>;
+
+export type GetMangaRelatedQuery = {
+    __typename: 'Query';
+    mangaRelated: {
+        __typename: 'MangaRelatedPayload';
+        anilistRelations: Array<{
+            __typename: 'TrackRelatedMangaType';
+            remoteId: string;
+            title: string;
+            coverUrl: string;
+            trackingUrl: string;
+            relationType: string | null;
+        }>;
+        anilistRecommendations: Array<{
+            __typename: 'TrackRelatedMangaType';
+            remoteId: string;
+            title: string;
+            coverUrl: string;
+            trackingUrl: string;
+            relationType: string | null;
+        }>;
+        myanimelistRelations: Array<{
+            __typename: 'TrackRelatedMangaType';
+            remoteId: string;
+            title: string;
+            coverUrl: string;
+            trackingUrl: string;
+            relationType: string | null;
+        }>;
+        myanimelistRecommendations: Array<{
+            __typename: 'TrackRelatedMangaType';
+            remoteId: string;
+            title: string;
+            coverUrl: string;
+            trackingUrl: string;
+            relationType: string | null;
+        }>;
+    };
+};
+
 export type UpdaterMangaFieldsFragment = {
     __typename: 'MangaUpdateType';
     status: Types.MangaJobStatus;

--- a/src/lib/graphql/tracker/TrackerQuery.ts
+++ b/src/lib/graphql/tracker/TrackerQuery.ts
@@ -56,3 +56,34 @@ export const TRACKER_SEARCH = gql`
         }
     }
 `;
+
+export const RELATED_MANGA_FIELDS = gql`
+    fragment RELATED_MANGA_FIELDS on TrackRelatedMangaType {
+        remoteId
+        title
+        coverUrl
+        trackingUrl
+        relationType
+    }
+`;
+
+export const GET_MANGA_RELATED = gql`
+    ${RELATED_MANGA_FIELDS}
+
+    query GET_MANGA_RELATED($mangaId: Int!) {
+        mangaRelated(input: { mangaId: $mangaId }) {
+            anilistRelations {
+                ...RELATED_MANGA_FIELDS
+            }
+            anilistRecommendations {
+                ...RELATED_MANGA_FIELDS
+            }
+            myanimelistRelations {
+                ...RELATED_MANGA_FIELDS
+            }
+            myanimelistRecommendations {
+                ...RELATED_MANGA_FIELDS
+            }
+        }
+    }
+`;

--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -84,6 +84,8 @@ import type {
     GetMangaChaptersFetchMutationVariables,
     GetMangaFetchMutation,
     GetMangaFetchMutationVariables,
+    GetMangaRelatedQuery,
+    GetMangaRelatedQueryVariables,
     GetMangasLibraryQuery,
     GetMangasLibraryQueryVariables,
     GetMangaToMigrateQuery,
@@ -307,7 +309,7 @@ import { GET_DOWNLOAD_STATUS } from '@/lib/graphql/download/DownloaderQuery.ts';
 import { defaultPromiseErrorHandler } from '@/lib/DefaultPromiseErrorHandler.ts';
 import type { QueuePriority } from '@/lib/Queue.ts';
 import { SourceAwareQueue } from '@/lib/SourceAwareQueue.ts';
-import { TRACKER_SEARCH } from '@/lib/graphql/tracker/TrackerQuery.ts';
+import { GET_MANGA_RELATED, TRACKER_SEARCH } from '@/lib/graphql/tracker/TrackerQuery.ts';
 import {
     TRACKER_BIND,
     TRACKER_FETCH_BIND,
@@ -3696,6 +3698,13 @@ export class RequestManager {
         options?: QueryHookOptions<TrackerSearchQuery, TrackerSearchQueryVariables>,
     ): AbortableApolloUseQueryResponse<TrackerSearchQuery, TrackerSearchQueryVariables> {
         return this.doRequest(GQLMethod.USE_QUERY, TRACKER_SEARCH, { trackerId, query }, options);
+    }
+
+    public useGetMangaRelated(
+        mangaId: number,
+        options?: QueryHookOptions<GetMangaRelatedQuery, GetMangaRelatedQueryVariables>,
+    ): AbortableApolloUseQueryResponse<GetMangaRelatedQuery, GetMangaRelatedQueryVariables> {
+        return this.doRequest(GQLMethod.USE_QUERY, GET_MANGA_RELATED, { mangaId }, options);
     }
 
     public useBindTracker(

--- a/src/lib/requests/RequestManager.ts
+++ b/src/lib/requests/RequestManager.ts
@@ -3707,10 +3707,23 @@ export class RequestManager {
         return this.doRequest(GQLMethod.USE_QUERY, GET_MANGA_RELATED, { mangaId }, options);
     }
 
+    /**
+     * Evicts the cached "mangaRelated" results so they are refetched the next time the Related
+     * modal is opened. The related/recommendation data depends on the manga's tracker bindings
+     * (which remote id is used), so it has to be invalidated whenever a binding changes.
+     */
+    private evictMangaRelated(): void {
+        this.graphQLClient.client.cache.evict({ fieldName: 'mangaRelated' });
+        this.graphQLClient.client.cache.gc();
+    }
+
     public useBindTracker(
         options?: MutationHookOptions<TrackerBindMutation, TrackerBindMutationVariables>,
     ): AbortableApolloUseMutationResponse<TrackerBindMutation, TrackerBindMutationVariables> {
-        return this.doRequest(GQLMethod.USE_MUTATION, TRACKER_BIND, undefined, options);
+        return this.doRequest(GQLMethod.USE_MUTATION, TRACKER_BIND, undefined, {
+            update: () => this.evictMangaRelated(),
+            ...options,
+        });
     }
 
     public bindTracker(
@@ -3720,11 +3733,14 @@ export class RequestManager {
         asPrivate: boolean,
         options?: MutationOptions<TrackerBindMutation, TrackerBindMutationVariables>,
     ): AbortableApolloMutationResponse<TrackerBindMutation> {
-        return this.doRequest(
+        return this.doRequest<TrackerBindMutation, TrackerBindMutationVariables>(
             GQLMethod.MUTATION,
             TRACKER_BIND,
             { input: { mangaId, remoteId, trackerId, private: asPrivate } },
-            options,
+            {
+                update: () => this.evictMangaRelated(),
+                ...options,
+            } as MutationOptions<TrackerBindMutation, TrackerBindMutationVariables>,
         );
     }
 
@@ -3737,10 +3753,11 @@ export class RequestManager {
             GQLMethod.MUTATION,
             TRACKER_UNBIND,
             { input: { recordId, deleteRemoteTrack } },
-            { refetchQueries: [GET_MANGA_TRACK_RECORDS], ...options } as MutationOptions<
-                TrackerUnbindMutation,
-                TrackerUnbindMutationVariables
-            >,
+            {
+                refetchQueries: [GET_MANGA_TRACK_RECORDS],
+                update: () => this.evictMangaRelated(),
+                ...options,
+            } as MutationOptions<TrackerUnbindMutation, TrackerUnbindMutationVariables>,
         );
     }
 


### PR DESCRIPTION
## What this does

Adds a **"Related"** button next to the "Tracking" button on the manga details page. It opens a modal with four rows of cover cards:

- **AniList – Relations**
- **AniList – Recommendations**
- **MyAnimeList – Related Entries**
- **MyAnimeList – Recommendations**

Each row is headed by the tracker's logo and shows a horizontally scrolling list of cover cards (relations also show the relation type, e.g. "Prequel"). Clicking a card opens that entry on the tracker's site in a new tab.

A new **Settings → Browse → "Show related for each manga"** toggle (default on, described as "Currently supported for: AniList, MyAnimeList") controls the button's visibility.

## Rationale

Gives a quick way to discover related works and recommendations for a manga, sourced from the trackers the user already uses, without leaving the app.

## Behaviour notes

- The related data is resolved per tracker from the manga's existing tracker binding, or a confident title-search fallback (handled server-side).
- The `mangaRelated` result is evicted from the Apollo cache on tracker bind/unbind, so it refreshes when the binding (and therefore the resolved entry) changes.

## Depends on

- Suwayomi/Suwayomi-Server#2132 — adds the `mangaRelated` GraphQL query this PR consumes. This will not function until that is merged and released. The generated GraphQL types here were added for that query and can be regenerated with `pnpm gql:codegen` against a server built from the companion PR.

## Testing

- `tsc` clean, `oxlint`/`oxfmt` clean, i18n strings extracted.
- Verified end-to-end against a local server built from the companion PR (settings toggle, button visibility, the four populated rows, and outbound card links).

## Visual changes

Adds the "Related" button to the details action row and a new modal; adds one toggle row under Settings → Browse. 

<img width="376" height="381" alt="image" src="https://github.com/user-attachments/assets/2699b88e-8166-44e9-9d63-7475105cfded" />

<img width="1191" height="1285" alt="image" src="https://github.com/user-attachments/assets/d14563bb-3d18-4579-8366-a51eb90a6b33" />
