### PR TITLE
feat: show filtered count in library tab and title badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - (**Manga**) Add share button (secure context (localhost, https))
 - (**Reader**) Add share button to desktop navigation bar (secure context (localhost, https))
+- (**Library**) Show filtered item count in active category tab
 
 ### Changed
 

--- a/src/features/library/hooks/useGetVisibleLibraryMangas.ts
+++ b/src/features/library/hooks/useGetVisibleLibraryMangas.ts
@@ -245,7 +245,6 @@ export const useGetVisibleLibraryMangas = <Manga extends MangaIdInfo & TMangasFi
     visibleMangas: Manga[];
     showFilteredOutMessage: boolean;
     filterKey: string;
-    isFiltered: boolean;
 } => {
     const [query] = useQueryParam(SearchParam.QUERY, StringParam);
     const options = useGetCategoryMetadata(category ?? DEFAULT_CATEGORY);
@@ -304,12 +303,9 @@ export const useGetVisibleLibraryMangas = <Manga extends MangaIdInfo & TMangasFi
         filteredMangas.length === 0 &&
         mangas.length > 0;
 
-    const isFiltered = filteredMangas.length !== mangas.length;
-
     return {
         visibleMangas: filteredMangas,
         showFilteredOutMessage,
         filterKey: `${JSON.stringify(options)}${settings.ignoreFilters}`,
-        isFiltered,
     };
 };

--- a/src/features/library/hooks/useGetVisibleLibraryMangas.ts
+++ b/src/features/library/hooks/useGetVisibleLibraryMangas.ts
@@ -245,6 +245,7 @@ export const useGetVisibleLibraryMangas = <Manga extends MangaIdInfo & TMangasFi
     visibleMangas: Manga[];
     showFilteredOutMessage: boolean;
     filterKey: string;
+    isFiltered: boolean;
 } => {
     const [query] = useQueryParam(SearchParam.QUERY, StringParam);
     const options = useGetCategoryMetadata(category ?? DEFAULT_CATEGORY);
@@ -303,9 +304,12 @@ export const useGetVisibleLibraryMangas = <Manga extends MangaIdInfo & TMangasFi
         filteredMangas.length === 0 &&
         mangas.length > 0;
 
+    const isFiltered = filteredMangas.length !== mangas.length;
+
     return {
         visibleMangas: filteredMangas,
         showFilteredOutMessage,
         filterKey: `${JSON.stringify(options)}${settings.ignoreFilters}`,
+        isFiltered,
     };
 };

--- a/src/features/library/screens/Library.tsx
+++ b/src/features/library/screens/Library.tsx
@@ -195,7 +195,8 @@ export function Library() {
             {t`Library`}
             {showTabSize && (
                 <TitleSizeTag
-                    sx={{ ...theme.applyStyles('light', { backgroundColor: 'background.paper' }) }}
+                    sx={{ ...(!isFiltered && theme.applyStyles('light', { backgroundColor: 'background.paper' })) }}
+                    color={isFiltered ? 'warning' : 'default'}
                     label={isFiltered ? `${mangas.length}/${librarySize}` : librarySize}
                 />
             )}
@@ -299,6 +300,7 @@ export function Library() {
                                 {tab.name}
                                 {showTabSize ? (
                                     <TitleSizeTag
+                                        color={tab === activeTab && isFiltered ? 'warning' : 'default'}
                                         label={
                                             tab === activeTab && isFiltered
                                                 ? `${mangas.length}/${tab.mangas.totalCount}`

--- a/src/features/library/screens/Library.tsx
+++ b/src/features/library/screens/Library.tsx
@@ -105,6 +105,7 @@ export function Library() {
         visibleMangas: mangas,
         showFilteredOutMessage,
         filterKey,
+        isFiltered,
     } = useGetVisibleLibraryMangas(categoryMangas, activeTab);
 
     const retryFetchCategoryMangas = useCallback(
@@ -195,12 +196,12 @@ export function Library() {
             {showTabSize && (
                 <TitleSizeTag
                     sx={{ ...theme.applyStyles('light', { backgroundColor: 'background.paper' }) }}
-                    label={librarySize}
+                    label={isFiltered ? `${mangas.length}/${librarySize}` : librarySize}
                 />
             )}
         </TitleWithSizeTag>,
         t`Library`,
-        [t, showTabSize, librarySize],
+        [t, showTabSize, librarySize, isFiltered, mangas.length],
     );
     useAppAction(
         <>
@@ -296,7 +297,15 @@ export function Library() {
                         label={
                             <TitleWithSizeTag>
                                 {tab.name}
-                                {showTabSize ? <TitleSizeTag label={tab.mangas.totalCount} /> : null}
+                                {showTabSize ? (
+                                    <TitleSizeTag
+                                        label={
+                                            tab === activeTab && isFiltered
+                                                ? `${mangas.length}/${tab.mangas.totalCount}`
+                                                : tab.mangas.totalCount
+                                        }
+                                    />
+                                ) : null}
                             </TitleWithSizeTag>
                         }
                         value={tab.id}

--- a/src/features/library/screens/Library.tsx
+++ b/src/features/library/screens/Library.tsx
@@ -105,8 +105,12 @@ export function Library() {
         visibleMangas: mangas,
         showFilteredOutMessage,
         filterKey,
-        isFiltered,
     } = useGetVisibleLibraryMangas(categoryMangas, activeTab);
+
+    const getTabCount = (tab: (typeof tabs)[number]) => {
+        if (tab !== activeTab || mangas.length === tab.mangas.totalCount) {return tab.mangas.totalCount;}
+        return `${mangas.length}/${tab.mangas.totalCount}`;
+    };
 
     const retryFetchCategoryMangas = useCallback(
         () => refetchCategoryMangas().catch(defaultPromiseErrorHandler('Library::refetchCategoryMangas')),
@@ -195,14 +199,13 @@ export function Library() {
             {t`Library`}
             {showTabSize && (
                 <TitleSizeTag
-                    sx={{ ...(!isFiltered && theme.applyStyles('light', { backgroundColor: 'background.paper' })) }}
-                    color={isFiltered ? 'warning' : 'default'}
-                    label={isFiltered ? `${mangas.length}/${librarySize}` : librarySize}
+                    sx={{ ...theme.applyStyles('light', { backgroundColor: 'background.paper' }) }}
+                    label={librarySize}
                 />
             )}
         </TitleWithSizeTag>,
         t`Library`,
-        [t, showTabSize, librarySize, isFiltered, mangas.length],
+        [t, showTabSize, librarySize],
     );
     useAppAction(
         <>
@@ -298,16 +301,7 @@ export function Library() {
                         label={
                             <TitleWithSizeTag>
                                 {tab.name}
-                                {showTabSize ? (
-                                    <TitleSizeTag
-                                        color={tab === activeTab && isFiltered ? 'warning' : 'default'}
-                                        label={
-                                            tab === activeTab && isFiltered
-                                                ? `${mangas.length}/${tab.mangas.totalCount}`
-                                                : tab.mangas.totalCount
-                                        }
-                                    />
-                                ) : null}
+                                {showTabSize ? <TitleSizeTag label={getTabCount(tab)} /> : null}
                             </TitleWithSizeTag>
                         }
                         value={tab.id}

--- a/src/features/library/screens/Library.tsx
+++ b/src/features/library/screens/Library.tsx
@@ -108,7 +108,9 @@ export function Library() {
     } = useGetVisibleLibraryMangas(categoryMangas, activeTab);
 
     const getTabCount = (tab: (typeof tabs)[number]) => {
-        if (tab !== activeTab || mangas.length === tab.mangas.totalCount) {return tab.mangas.totalCount;}
+        if (tab !== activeTab || mangas.length === tab.mangas.totalCount) {
+            return tab.mangas.totalCount;
+        }
         return `${mangas.length}/${tab.mangas.totalCount}`;
     };
 


### PR DESCRIPTION
When filtering a library, I never know how many items are filtered without selecting them all.

This is my attempt at adding this functionality, as well as making sure to highlight similar to the filter icon, to make it more prominent that we are filtering.

### Changes

- When filters or search reduce the visible manga count, the count badge displays `filtered/total` (e.g. `5/20`) instead of just the total
- The count badge uses the same `warning` color as the filter icon when filtering is active, visually tying them together
- Applies to both the Library title badge and the active category tab badge