### PR TITLE
Add hidden library categories with a client-side lock

### DIFF
--- a/src/base/components/AppbarSearch.tsx
+++ b/src/base/components/AppbarSearch.tsx
@@ -20,10 +20,11 @@ import { SearchParam } from '@/base/Base.types.ts';
 
 interface IProps {
     isClosable?: boolean;
+    onSubmit?: (query: string) => boolean | Promise<boolean>;
 }
 
 export const AppbarSearch: React.FunctionComponent<IProps> = (props) => {
-    const { isClosable = true } = props;
+    const { isClosable = true, onSubmit } = props;
 
     const theme = useTheme();
     const { t } = useLingui();
@@ -59,8 +60,15 @@ export const AppbarSearch: React.FunctionComponent<IProps> = (props) => {
         }
     };
 
-    function handleChange(newQuery: string) {
+    async function handleChange(newQuery: string) {
         if (newQuery === '') {
+            return;
+        }
+
+        if (await onSubmit?.(newQuery)) {
+            setSearchString('');
+            setQuery(undefined);
+            updateSearchOpenState(false);
             return;
         }
 
@@ -97,7 +105,7 @@ export const AppbarSearch: React.FunctionComponent<IProps> = (props) => {
                 onChange={(e) => setSearchString(e.target.value)}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter') {
-                        handleChange(searchString);
+                        void handleChange(searchString);
                     }
                 }}
                 onBlur={handleBlur}

--- a/src/features/library/HiddenCategories.utils.ts
+++ b/src/features/library/HiddenCategories.utils.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+export const HIDDEN_CATEGORIES_SESSION_KEY = 'suwayomi.hidden-categories.unlocked';
+export const HIDDEN_CATEGORIES_UNLOCKED_AT_SESSION_KEY = 'suwayomi.hidden-categories.unlocked-at';
+
+export const hashHiddenCategoryPassword = async (password: string): Promise<string> => {
+    if (!globalThis.crypto?.subtle) {
+        throw new Error('The Web Crypto API is unavailable');
+    }
+
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(password));
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+};

--- a/src/features/library/Library.types.ts
+++ b/src/features/library/Library.types.ts
@@ -12,6 +12,10 @@ import type { MangaDescriptionInfo, MangaIdInfo, MangaTitleInfo } from '@/featur
 import type { TrackerIdInfo } from '@/features/tracker/Tracker.types.ts';
 
 export type MetadataLibrarySettings = {
+    hiddenCategoryIds: number[];
+    hiddenCategoryPasswordHash: string;
+    hiddenCategoryAutoLockEnabled: boolean;
+    hiddenCategoryAutoLockMinutes: number;
     showAddToLibraryCategorySelectDialog: boolean;
     ignoreFilters: boolean;
     removeMangaFromCategories: boolean;

--- a/src/features/library/components/HiddenCategoriesSetting.tsx
+++ b/src/features/library/components/HiddenCategoriesSetting.tsx
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import { plural } from '@lingui/core/macro';
+import { useLingui } from '@lingui/react/macro';
+import { makeToast } from '@/base/utils/Toast.ts';
+import type { GetCategoriesSettingsQuery } from '@/lib/graphql/generated/graphql.ts';
+import { requestServerMetadataUpdate } from '@/features/metadata/services/MetadataUpdater.ts';
+import { getErrorMessage } from '@/lib/HelperFunctions.ts';
+import { hashHiddenCategoryPassword } from '@/features/library/HiddenCategories.utils.ts';
+
+type Category = GetCategoriesSettingsQuery['categories']['nodes'][number];
+
+const updateSettings = async (
+    nextIds: number[],
+    nextPasswordHash: string,
+    autoLockEnabled: boolean,
+    autoLockMinutes: number,
+) =>
+    requestServerMetadataUpdate({
+        update: [
+            ['hiddenCategoryIds', JSON.stringify(nextIds)],
+            ['hiddenCategoryPasswordHash', nextPasswordHash],
+            ['hiddenCategoryAutoLockEnabled', autoLockEnabled],
+            ['hiddenCategoryAutoLockMinutes', autoLockMinutes],
+        ],
+    });
+
+export const HiddenCategoriesSetting = ({
+    categories,
+    hiddenCategoryIds,
+    passwordHash,
+    autoLockEnabled,
+    autoLockMinutes,
+}: {
+    categories: Category[];
+    hiddenCategoryIds: number[];
+    passwordHash: string;
+    autoLockEnabled: boolean;
+    autoLockMinutes: number;
+}) => {
+    const { t } = useLingui();
+    const [isOpen, setIsOpen] = useState(false);
+    const [isAuthorized, setIsAuthorized] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmedPassword, setConfirmedPassword] = useState('');
+    const [selectedIds, setSelectedIds] = useState<number[]>(hiddenCategoryIds);
+    const [passwordError, setPasswordError] = useState('');
+    const [isAutoLockEnabled, setIsAutoLockEnabled] = useState(autoLockEnabled);
+    const [autoLockMinutesInput, setAutoLockMinutesInput] = useState(String(autoLockMinutes));
+    const [autoLockError, setAutoLockError] = useState('');
+
+    const isConfigured = hiddenCategoryIds.length > 0 && !!passwordHash;
+    const selectableCategories = categories.filter(({ id }) => id !== 0);
+
+    const openDialog = () => {
+        setSelectedIds(hiddenCategoryIds);
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmedPassword('');
+        setPasswordError('');
+        setIsAutoLockEnabled(autoLockEnabled);
+        setAutoLockMinutesInput(String(autoLockMinutes));
+        setAutoLockError('');
+        setIsAuthorized(!isConfigured);
+        setIsOpen(true);
+    };
+
+    const closeDialog = () => {
+        if (!isSaving) {
+            setIsOpen(false);
+        }
+    };
+
+    const verifyPassword = async () => {
+        try {
+            if ((await hashHiddenCategoryPassword(currentPassword)) !== passwordHash) {
+                setPasswordError(t`Incorrect access code`);
+                return;
+            }
+
+            setPasswordError('');
+            setIsAuthorized(true);
+            setCurrentPassword('');
+        } catch (error) {
+            makeToast(t`Could not verify access code`, 'error', getErrorMessage(error));
+        }
+    };
+
+    const saveSettings = async () => {
+        setPasswordError('');
+        setAutoLockError('');
+
+        const nextAutoLockMinutes = Number(autoLockMinutesInput);
+        if (isAutoLockEnabled && (!Number.isInteger(nextAutoLockMinutes) || nextAutoLockMinutes < 1)) {
+            setAutoLockError(t`Enter a whole number of minutes greater than zero`);
+            return;
+        }
+
+        const validAutoLockMinutes = Number.isInteger(nextAutoLockMinutes)
+            ? Math.max(1, nextAutoLockMinutes)
+            : autoLockMinutes;
+
+        if (!selectedIds.length) {
+            setIsSaving(true);
+            try {
+                await updateSettings([], '', isAutoLockEnabled, validAutoLockMinutes);
+                setIsOpen(false);
+                makeToast(t`Hidden categories disabled`, 'success');
+            } catch (error) {
+                makeToast(t`Could not save hidden categories`, 'error', getErrorMessage(error));
+            } finally {
+                setIsSaving(false);
+            }
+            return;
+        }
+
+        if (!passwordHash && newPassword.length < 4) {
+            setPasswordError(t`Access code must contain at least 4 characters`);
+            return;
+        }
+
+        if (newPassword && newPassword.length < 4) {
+            setPasswordError(t`Access code must contain at least 4 characters`);
+            return;
+        }
+
+        if (newPassword !== confirmedPassword) {
+            setPasswordError(t`Access codes do not match`);
+            return;
+        }
+
+        setIsSaving(true);
+        try {
+            const nextPasswordHash = newPassword ? await hashHiddenCategoryPassword(newPassword) : passwordHash;
+            await updateSettings(selectedIds, nextPasswordHash, isAutoLockEnabled, validAutoLockMinutes);
+            setIsOpen(false);
+            makeToast(t`Hidden categories saved`, 'success');
+        } catch (error) {
+            makeToast(t`Could not save hidden categories`, 'error', getErrorMessage(error));
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    return (
+        <>
+            <ListItemButton onClick={openDialog}>
+                <ListItemText
+                    primary={t`Hidden categories`}
+                    secondary={
+                        isConfigured
+                            ? plural(hiddenCategoryIds.length, {
+                                  one: '# hidden category',
+                                  other: '# hidden categories',
+                              })
+                            : t`Not configured`
+                    }
+                />
+            </ListItemButton>
+            <Dialog open={isOpen} onClose={closeDialog} fullWidth maxWidth="xs">
+                <DialogTitle>{isAuthorized ? t`Hidden categories` : t`Unlock hidden category settings`}</DialogTitle>
+                {!isAuthorized ? (
+                    <>
+                        <DialogContent>
+                            <TextField
+                                autoFocus
+                                fullWidth
+                                margin="dense"
+                                type="password"
+                                label={t`Current access code`}
+                                value={currentPassword}
+                                error={!!passwordError}
+                                helperText={passwordError}
+                                onChange={(event) => setCurrentPassword(event.target.value)}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter' && currentPassword) {
+                                        void verifyPassword();
+                                    }
+                                }}
+                            />
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={closeDialog}>{t`Cancel`}</Button>
+                            <Button
+                                onClick={() => void verifyPassword()}
+                                disabled={!currentPassword}
+                                variant="contained"
+                            >
+                                {t`Unlock`}
+                            </Button>
+                        </DialogActions>
+                    </>
+                ) : (
+                    <>
+                        <DialogContent dividers>
+                            <Stack sx={{ gap: 2 }}>
+                                <FormGroup>
+                                    {selectableCategories.map((category) => (
+                                        <FormControlLabel
+                                            key={category.id}
+                                            label={category.name}
+                                            control={
+                                                <Checkbox
+                                                    checked={selectedIds.includes(category.id)}
+                                                    onChange={(event) =>
+                                                        setSelectedIds((current) =>
+                                                            event.target.checked
+                                                                ? [...current, category.id]
+                                                                : current.filter((id) => id !== category.id),
+                                                        )
+                                                    }
+                                                />
+                                            }
+                                        />
+                                    ))}
+                                </FormGroup>
+                                <FormControlLabel
+                                    label={t`Lock automatically`}
+                                    control={
+                                        <Switch
+                                            checked={isAutoLockEnabled}
+                                            onChange={(event) => {
+                                                setIsAutoLockEnabled(event.target.checked);
+                                                setAutoLockError('');
+                                            }}
+                                        />
+                                    }
+                                />
+                                {isAutoLockEnabled && (
+                                    <TextField
+                                        fullWidth
+                                        type="number"
+                                        label={t`Lock after (minutes)`}
+                                        value={autoLockMinutesInput}
+                                        error={!!autoLockError}
+                                        helperText={autoLockError}
+                                        slotProps={{ htmlInput: { min: 1, step: 1 } }}
+                                        onChange={(event) => {
+                                            setAutoLockMinutesInput(event.target.value);
+                                            setAutoLockError('');
+                                        }}
+                                    />
+                                )}
+                                <TextField
+                                    fullWidth
+                                    type="password"
+                                    label={isConfigured ? t`New access code (optional)` : t`Access code`}
+                                    value={newPassword}
+                                    error={!!passwordError}
+                                    onChange={(event) => {
+                                        setNewPassword(event.target.value);
+                                        setPasswordError('');
+                                    }}
+                                />
+                                <TextField
+                                    fullWidth
+                                    type="password"
+                                    label={t`Confirm access code`}
+                                    value={confirmedPassword}
+                                    error={!!passwordError}
+                                    helperText={passwordError}
+                                    disabled={!newPassword}
+                                    onChange={(event) => {
+                                        setConfirmedPassword(event.target.value);
+                                        setPasswordError('');
+                                    }}
+                                />
+                            </Stack>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={closeDialog} disabled={isSaving}>
+                                {t`Cancel`}
+                            </Button>
+                            <Button onClick={() => void saveSettings()} disabled={isSaving} variant="contained">
+                                {isSaving ? t`Saving…` : t`Save`}
+                            </Button>
+                        </DialogActions>
+                    </>
+                )}
+            </Dialog>
+        </>
+    );
+};

--- a/src/features/library/screens/Library.tsx
+++ b/src/features/library/screens/Library.tsx
@@ -10,11 +10,13 @@ import type { ChipProps } from '@mui/material/Chip';
 import Chip from '@mui/material/Chip';
 import Tab from '@mui/material/Tab';
 import { styled, useTheme } from '@mui/material/styles';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryParam, NumberParam, StringParam } from 'use-query-params';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useLingui } from '@lingui/react/macro';
 import { plural } from '@lingui/core/macro';
 import { requestManager } from '@/lib/requests/RequestManager.ts';
@@ -51,6 +53,12 @@ import { AppRoutes } from '@/base/AppRoute.constants.ts';
 import { SearchParam } from '@/base/Base.types.ts';
 import { STABLE_EMPTY_ARRAY } from '@/base/Base.constants.ts';
 import type { MangaIdInfo } from '@/features/manga/Manga.types.ts';
+import { CustomTooltip } from '@/base/components/CustomTooltip.tsx';
+import {
+    HIDDEN_CATEGORIES_SESSION_KEY,
+    HIDDEN_CATEGORIES_UNLOCKED_AT_SESSION_KEY,
+    hashHiddenCategoryPassword,
+} from '@/features/library/HiddenCategories.utils.ts';
 import { OffsetComponent } from '@/base/OffsetComponent.tsx';
 
 const TitleWithSizeTag = styled('span')({
@@ -65,10 +73,91 @@ const TitleSizeTag = ({ sx, ...props }: ChipProps) => (
 export function Library() {
     const { t } = useLingui();
     const theme = useTheme();
+    const [unlockedPasswordHash, setUnlockedPasswordHash] = useState(
+        () => sessionStorage.getItem(HIDDEN_CATEGORIES_SESSION_KEY) ?? '',
+    );
+    const [unlockedAt, setUnlockedAt] = useState(
+        () => Number(sessionStorage.getItem(HIDDEN_CATEGORIES_UNLOCKED_AT_SESSION_KEY)) || 0,
+    );
 
     const {
-        settings: { showTabSize },
+        settings: {
+            hiddenCategoryIds,
+            hiddenCategoryPasswordHash,
+            hiddenCategoryAutoLockEnabled,
+            hiddenCategoryAutoLockMinutes,
+            showTabSize,
+        },
     } = useMetadataServerSettings();
+    const lockHiddenCategories = useCallback(() => {
+        sessionStorage.removeItem(HIDDEN_CATEGORIES_SESSION_KEY);
+        sessionStorage.removeItem(HIDDEN_CATEGORIES_UNLOCKED_AT_SESSION_KEY);
+        setUnlockedPasswordHash('');
+        setUnlockedAt(0);
+    }, []);
+    const hasMatchingUnlockHash = !!hiddenCategoryPasswordHash && unlockedPasswordHash === hiddenCategoryPasswordHash;
+    const areHiddenCategoriesUnlocked =
+        hasMatchingUnlockHash &&
+        (!hiddenCategoryAutoLockEnabled ||
+            (!!unlockedAt && Date.now() < unlockedAt + hiddenCategoryAutoLockMinutes * 60_000));
+
+    useEffect(() => {
+        if (!hasMatchingUnlockHash || !hiddenCategoryAutoLockEnabled) {
+            return undefined;
+        }
+
+        if (!unlockedAt) {
+            const now = Date.now();
+            sessionStorage.setItem(HIDDEN_CATEGORIES_UNLOCKED_AT_SESSION_KEY, String(now));
+            setUnlockedAt(now);
+            return undefined;
+        }
+
+        let timeout: number;
+        const scheduleLock = () => {
+            const remainingTime = unlockedAt + hiddenCategoryAutoLockMinutes * 60_000 - Date.now();
+            if (remainingTime <= 0) {
+                lockHiddenCategories();
+                return;
+            }
+
+            timeout = window.setTimeout(scheduleLock, Math.min(remainingTime, 2_147_483_647));
+        };
+        scheduleLock();
+
+        return () => window.clearTimeout(timeout);
+    }, [
+        hasMatchingUnlockHash,
+        hiddenCategoryAutoLockEnabled,
+        hiddenCategoryAutoLockMinutes,
+        unlockedAt,
+        lockHiddenCategories,
+    ]);
+
+    const handleSearchSubmit = useCallback(
+        async (searchValue: string): Promise<boolean> => {
+            if (!hiddenCategoryIds.length || !hiddenCategoryPasswordHash || areHiddenCategoriesUnlocked) {
+                return false;
+            }
+
+            try {
+                const searchHash = await hashHiddenCategoryPassword(searchValue);
+                if (searchHash !== hiddenCategoryPasswordHash) {
+                    return false;
+                }
+
+                const now = Date.now();
+                sessionStorage.setItem(HIDDEN_CATEGORIES_SESSION_KEY, searchHash);
+                sessionStorage.setItem(HIDDEN_CATEGORIES_UNLOCKED_AT_SESSION_KEY, String(now));
+                setUnlockedPasswordHash(searchHash);
+                setUnlockedAt(now);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        [hiddenCategoryIds.length, hiddenCategoryPasswordHash, areHiddenCategoriesUnlocked],
+    );
 
     const {
         data: categoriesResponse,
@@ -78,9 +167,9 @@ export function Library() {
     } = requestManager.useGetCategories<GetCategoriesLibraryQuery, GetCategoriesLibraryQueryVariables>(
         GET_CATEGORIES_LIBRARY,
     );
-    const tabsData = categoriesResponse?.categories.nodes.filter(
-        (category) => category.id !== 0 || (category.id === 0 && category.mangas.totalCount),
-    );
+    const tabsData = categoriesResponse?.categories.nodes
+        .filter((category) => category.id !== 0 || (category.id === 0 && category.mangas.totalCount))
+        .filter((category) => areHiddenCategoriesUnlocked || !hiddenCategoryIds.includes(category.id));
     const tabs = tabsData ?? STABLE_EMPTY_ARRAY;
 
     const librarySizeResponse = requestManager.useGetMangas<GetMangasCountQuery, GetMangasCountQueryVariables>(
@@ -215,7 +304,14 @@ export function Library() {
         <>
             {!isSelectModeActive && activeTab && (
                 <>
-                    <AppbarSearch />
+                    <AppbarSearch onSubmit={handleSearchSubmit} />
+                    {areHiddenCategoriesUnlocked && (
+                        <CustomTooltip title={t`Lock hidden categories`}>
+                            <IconButton onClick={lockHiddenCategories} color="inherit">
+                                <LockOutlinedIcon />
+                            </IconButton>
+                        </CustomTooltip>
+                    )}
                     <LibraryToolbarMenu category={activeTab} mangas={mangas} />
                     <UpdateChecker categoryId={activeTab?.id} />
                 </>
@@ -240,7 +336,16 @@ export function Library() {
                 />
             )}
         </>,
-        [isSelectModeActive, areNoItemsSelected, areAllItemsSelected, activeTab, mangas],
+        [
+            isSelectModeActive,
+            areNoItemsSelected,
+            areAllItemsSelected,
+            activeTab,
+            mangas,
+            areHiddenCategoriesUnlocked,
+            handleSearchSubmit,
+            lockHiddenCategories,
+        ],
     );
 
     const handleTabChange = (newTab: number) => {

--- a/src/features/library/screens/LibrarySettings.tsx
+++ b/src/features/library/screens/LibrarySettings.tsx
@@ -38,6 +38,7 @@ import type { MetadataLibrarySettings } from '@/features/library/Library.types.t
 import { AppRoutes } from '@/base/AppRoute.constants.ts';
 import { getErrorMessage } from '@/lib/HelperFunctions.ts';
 import { useAppTitle } from '@/features/navigation-bar/hooks/useAppTitle.ts';
+import { HiddenCategoriesSetting } from '@/features/library/components/HiddenCategoriesSetting.tsx';
 
 const removeNonLibraryMangasFromCategories = async (): Promise<void> => {
     try {
@@ -138,6 +139,13 @@ export function LibrarySettings() {
                         })}
                     />
                 </ListItemLink>
+                <HiddenCategoriesSetting
+                    categories={categories.data!.categories.nodes}
+                    hiddenCategoryIds={settings.hiddenCategoryIds}
+                    passwordHash={settings.hiddenCategoryPasswordHash}
+                    autoLockEnabled={settings.hiddenCategoryAutoLockEnabled}
+                    autoLockMinutes={settings.hiddenCategoryAutoLockMinutes}
+                />
                 <ListItem>
                     <ListItemText
                         primary={t`Category selection dialog`}

--- a/src/features/metadata/Metadata.constants.ts
+++ b/src/features/metadata/Metadata.constants.ts
@@ -110,6 +110,19 @@ export const APP_METADATA: Record<
     removeMangaFromCategories: {
         convert: convertToBoolean,
     },
+    hiddenCategoryIds: {
+        convert: convertToObject<number[]>,
+    },
+    hiddenCategoryPasswordHash: {
+        convert: convertToString,
+    },
+    hiddenCategoryAutoLockEnabled: {
+        convert: convertToBoolean,
+    },
+    hiddenCategoryAutoLockMinutes: {
+        convert: convertToNumber,
+        toConstrainedValue: (value: number) => (Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 10),
+    },
     showTabSize: {
         convert: convertToBoolean,
     },
@@ -432,6 +445,10 @@ export const GLOBAL_METADATA_KEYS: AppMetadataKeys[] = [
     'showAddToLibraryCategorySelectDialog',
     'ignoreFilters',
     'removeMangaFromCategories',
+    'hiddenCategoryIds',
+    'hiddenCategoryPasswordHash',
+    'hiddenCategoryAutoLockEnabled',
+    'hiddenCategoryAutoLockMinutes',
     'showTabSize',
 
     // library category options

--- a/src/features/settings/Settings.constants.ts
+++ b/src/features/settings/Settings.constants.ts
@@ -49,6 +49,10 @@ export const SERVER_SETTINGS_METADATA_DEFAULT: MetadataServerSettings = {
     downloadAheadLimit: 0,
 
     // library
+    hiddenCategoryIds: [],
+    hiddenCategoryPasswordHash: '',
+    hiddenCategoryAutoLockEnabled: true,
+    hiddenCategoryAutoLockMinutes: 10,
     showAddToLibraryCategorySelectDialog: true,
     ignoreFilters: false,
     removeMangaFromCategories: false,

--- a/src/features/settings/services/ServerSettingsMetadata.ts
+++ b/src/features/settings/services/ServerSettingsMetadata.ts
@@ -24,6 +24,7 @@ export const convertSettingsToMetadata = (
     customThemes: JSON.stringify(settings.customThemes),
     migrateSortSettings: JSON.stringify(settings.migrateSortSettings),
     browseLanguages: JSON.stringify(settings.browseLanguages),
+    hiddenCategoryIds: JSON.stringify(settings.hiddenCategoryIds),
 });
 
 const getMetadataServerSettingsWithDefaultFallback = (

--- a/src/i18n/locales/en.po
+++ b/src/i18n/locales/en.po
@@ -35,6 +35,11 @@ msgstr "{0, plural, one {# Chapter} other {# Chapters}}"
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# day} other {# days}}"
 
+#. placeholder {0}: hiddenCategoryIds.length
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "{0, plural, one {# hidden category} other {# hidden categories}}"
+msgstr "{0, plural, one {# hidden category} other {# hidden categories}}"
+
 #. placeholder {0}: selectedItemIds.length
 #: src/features/library/screens/Library.tsx
 msgid "{0, plural, one {# manga} other {# manga}}"
@@ -385,6 +390,18 @@ msgstr "Aborted"
 #: src/features/settings/screens/About.tsx
 msgid "About"
 msgstr "About"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Access code"
+msgstr "Access code"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Access code must contain at least 4 characters"
+msgstr "Access code must contain at least 4 characters"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Access codes do not match"
+msgstr "Access codes do not match"
 
 #: src/features/device/screens/DeviceSetting.tsx
 msgid "Active device"
@@ -765,6 +782,7 @@ msgstr "Can't migrate an entry to itself"
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/category/components/CreateOrEditCategoryDialog.tsx
 #: src/features/downloads/components/DownloadQueueChapterCard.tsx
+#: src/features/library/components/HiddenCategoriesSetting.tsx
 #: src/features/migration/components/MigrationBulkSearchOptionsDialog.tsx
 #: src/features/migration/components/MigrationOptionsDialog.tsx
 #: src/features/reader/hotkeys/settings/components/RecordHotkey.tsx
@@ -969,6 +987,10 @@ msgstr "Completed"
 #: src/features/settings/components/images/Processing.tsx
 msgid "Compression level"
 msgstr "Compression level"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Confirm access code"
+msgstr "Confirm access code"
 
 #: src/features/settings/components/images/Processing.tsx
 msgid "Connect timeout"
@@ -1193,6 +1215,10 @@ msgstr "Could not retry failed downloads"
 msgid "Could not save changes"
 msgstr "Could not save changes"
 
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Could not save hidden categories"
+msgstr "Could not save hidden categories"
+
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/library/components/LibraryOptionsPanel.tsx
 #: src/features/library/screens/LibrarySettings.tsx
@@ -1236,6 +1262,10 @@ msgstr "Could not update WebUI"
 msgid "Could not validate backup"
 msgstr "Could not validate backup"
 
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Could not verify access code"
+msgstr "Could not verify access code"
+
 #: src/features/category/components/CategorySelect.tsx
 #: src/features/device/screens/DeviceSetting.tsx
 #: src/features/reader/hotkeys/settings/components/RecordHotkey.tsx
@@ -1270,6 +1300,10 @@ msgstr "Creating theme…"
 #: src/features/theme/Themes.ts
 msgid "Crimson"
 msgstr "Crimson"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Current access code"
+msgstr "Current access code"
 
 #: src/features/migration/components/MigrationDestinationSourceList.tsx
 msgid "Current source"
@@ -1641,6 +1675,10 @@ msgstr "Enable page read progress"
 msgid "Enable the WebView via CEF (Chromium)"
 msgstr "Enable the WebView via CEF (Chromium)"
 
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Enter a whole number of minutes greater than zero"
+msgstr "Enter a whole number of minutes greater than zero"
+
 #: src/features/downloads/screens/DownloadSettings.tsx
 msgid "Entries in excluded categories will not be downloaded even if they are also in included categories"
 msgstr "Entries in excluded categories will not be downloaded even if they are also in included categories"
@@ -1969,6 +2007,18 @@ msgstr "Hiatus"
 msgid "Hidden"
 msgstr "Hidden"
 
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Hidden categories"
+msgstr "Hidden categories"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Hidden categories disabled"
+msgstr "Hidden categories disabled"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Hidden categories saved"
+msgstr "Hidden categories saved"
+
 #: src/features/browse/screens/BrowseSettings.tsx
 msgid "Hide entries already in library"
 msgstr "Hide entries already in library"
@@ -2095,6 +2145,10 @@ msgstr "Include: {includedCategoriesText}"
 #: src/features/settings/screens/ServerSettings.tsx
 msgid "Include: {includedSyncDataText}"
 msgstr "Include: {includedSyncDataText}"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Incorrect access code"
+msgstr "Incorrect access code"
 
 #: src/features/reader/hotkeys/settings/components/ReaderSettingHotkey.tsx
 msgid "Increase auto scroll speed"
@@ -2368,6 +2422,18 @@ msgstr "Local source guide"
 #: src/features/browse/screens/BrowseSettings.tsx
 msgid "Local source location"
 msgstr "Local source location"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Lock after (minutes)"
+msgstr "Lock after (minutes)"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Lock automatically"
+msgstr "Lock automatically"
+
+#: src/features/library/screens/Library.tsx
+msgid "Lock hidden categories"
+msgstr "Lock hidden categories"
 
 #: src/features/settings/screens/ServerSettings.tsx
 msgid "Log file cleanup"
@@ -2655,6 +2721,10 @@ msgstr "Name"
 msgid "Never"
 msgstr "Never"
 
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "New access code (optional)"
+msgstr "New access code (optional)"
+
 #: src/features/category/components/CreateOrEditCategoryDialog.tsx
 msgid "New category"
 msgstr "New category"
@@ -2729,6 +2799,10 @@ msgstr "No sources installed"
 #: src/features/settings/Settings.constants.ts
 msgid "None"
 msgstr "None"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Not configured"
+msgstr "Not configured"
 
 #: src/features/tracker/Tracker.constants.ts
 msgid "Not yet published"
@@ -3185,6 +3259,7 @@ msgstr "Right to left"
 msgid "Rosegold"
 msgstr "Rosegold"
 
+#: src/features/library/components/HiddenCategoriesSetting.tsx
 #: src/features/settings/screens/ImageProcessingSetting.tsx
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Save"
@@ -3214,6 +3289,10 @@ msgstr "Saved theme changes"
 #: src/features/theme/components/CreateThemeDialog.tsx
 msgid "Saving theme changes…"
 msgstr "Saving theme changes…"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Saving…"
+msgstr "Saving…"
 
 #: src/features/reader/overlay/navigation/desktop/quick-settings/components/ReaderNavBarDesktopPageScale.tsx
 #: src/features/reader/settings/layout/components/ReaderSettingPageScaleMode.tsx
@@ -4052,6 +4131,14 @@ msgstr "Unknown"
 #: src/features/migration/MigrationManager.ts
 msgid "Unknown source"
 msgstr "Unknown source"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Unlock"
+msgstr "Unlock"
+
+#: src/features/library/components/HiddenCategoriesSetting.tsx
+msgid "Unlock hidden category settings"
+msgstr "Unlock hidden category settings"
 
 #: src/features/browse/sources/components/SourceCard.tsx
 msgid "Unpin source"


### PR DESCRIPTION
## Summary

- allow selected categories to be hidden from the library interface
- reveal hidden categories by entering an access code through Library search
- provide manual locking and an optional configurable timed relock
- store the preference through existing WebUI metadata

## Scope

This feature provides client-side UI concealment for shared browser sessions. It is not an access-control boundary.

An authenticated user with API access or control over the browser can bypass the lock and access the underlying category data.

## Testing

- `pnpm format:check`
- `pnpm tsc`
- `pnpm lint`
- `pnpm build`
- verified category configuration, correct and incorrect access codes, search-field unlocking, manual and automatic relocking, persistence, and desktop and mobile layouts