### PR TITLE
Fix explicit theme color scheme selection

### DIFF
--- a/src/features/theme/AppThemeContext.tsx
+++ b/src/features/theme/AppThemeContext.tsx
@@ -9,7 +9,7 @@
 import type { ReactNode } from 'react';
 import React, { useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Direction } from '@mui/material/styles';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider, useColorScheme } from '@mui/material/styles';
 import { CacheProvider } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import type { AppTheme } from '@/features/theme/services/AppThemes.ts';
@@ -44,6 +44,18 @@ export const AppThemeContext = React.createContext<TAppThemeContext>({
 });
 
 export const useAppThemeContext = () => useContext(AppThemeContext);
+
+const ThemeModeSynchronizer = ({ themeMode }: { themeMode: ThemeMode }) => {
+    const { mode, setMode } = useColorScheme();
+
+    useLayoutEffect(() => {
+        if (mode !== themeMode) {
+            setMode(themeMode);
+        }
+    }, [mode, setMode, themeMode]);
+
+    return null;
+};
 
 export const AppThemeContextProvider = ({ children }: { children: ReactNode }) => {
     const { t } = useLingui();
@@ -158,7 +170,10 @@ export const AppThemeContextProvider = ({ children }: { children: ReactNode }) =
     return (
         <AppThemeContext.Provider value={appThemeContext}>
             <CacheProvider value={DIRECTION_TO_CACHE[currentDirection]}>
-                <ThemeProvider theme={theme}>{children}</ThemeProvider>
+                <ThemeProvider theme={theme}>
+                    <ThemeModeSynchronizer themeMode={actualThemeMode as ThemeMode} />
+                    {children}
+                </ThemeProvider>
             </CacheProvider>
         </AppThemeContext.Provider>
     );

--- a/src/features/theme/services/ThemeCreator.ts
+++ b/src/features/theme/services/ThemeCreator.ts
@@ -192,6 +192,7 @@ export const createTheme = (
     const suwayomiTheme = createMuiTheme(
         deepmerge(appColorTheme, {
             defaultColorScheme: mode,
+            colorSchemeSelector: 'class',
             direction,
             typography: {
                 fontSize: 13,


### PR DESCRIPTION
## Summary

- select MUI color schemes with the WebUI-controlled class selector
- synchronize MUI's persisted mode with Suwayomi's resolved theme mode
- keep explicit Light and Dark modes independent from the operating system color scheme
- preserve System mode behavior

## Root cause

The theme provided both light and dark color schemes but kept MUI's default `media` selector. With that selector, MUI's `setMode` API does not control the active CSS variables, so Chrome could select foreground colors from the Windows color scheme while the WebUI rendered a different background palette.

Changing to `colorSchemeSelector: 'class'` makes the active CSS variables follow MUI's mode class. The persisted MUI mode can also differ from the theme mode stored by Suwayomi, however, so the provider now synchronizes MUI with the resolved WebUI mode before paint.

Fixes #1146.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm tsc`
- `pnpm build`
- installed-runtime test with Suwayomi-Server v2.3.2243 and WebUI r3423 in Chrome on Windows 11
- dark WebUI rendered matching foreground and background colors under both Windows Light and Windows Dark
- Windows theme restored to Light after testing
